### PR TITLE
Add disableSpeedChallenges setting and endpoint

### DIFF
--- a/src/settings/dto/update-settings.dto.ts
+++ b/src/settings/dto/update-settings.dto.ts
@@ -35,6 +35,10 @@ export class UpdateSettingsDto {
   disableTabSwitch?: boolean;
 
   @IsOptional()
+  @IsBoolean()
+  disableSpeedChallenges?: boolean;
+
+  @IsOptional()
   @IsNumber()
   @Min(1)
   apiRateLimit?: number;

--- a/src/settings/schemas/settings.schema.ts
+++ b/src/settings/schemas/settings.schema.ts
@@ -10,6 +10,7 @@ export const SettingsSchema = new Schema(
     ollamaEnabled: { type: Boolean, default: true },
     disableCopyPaste: { type: Boolean, default: false },
     disableTabSwitch: { type: Boolean, default: false },
+    disableSpeedChallenges: { type: Boolean, default: false },
     apiRateLimit: { type: Number, default: 1000 },
     codeExecutionLimit: { type: Number, default: 100 },
   },

--- a/src/settings/settings.controller.ts
+++ b/src/settings/settings.controller.ts
@@ -26,6 +26,7 @@ const SETTING_LABELS: Record<string, string> = {
   ollamaEnabled: 'AI Classification',
   disableCopyPaste: 'Disable Copy/Paste',
   disableTabSwitch: 'Disable Tab Switch',
+  disableSpeedChallenges: 'Disable Speed Challenges',
   apiRateLimit: 'API Requests per Hour',
   codeExecutionLimit: 'Code Executions per Day',
 };
@@ -484,6 +485,70 @@ Content-Type: application/json
         previousState: { codeExecutionLimit: previous?.codeExecutionLimit },
         newState: { codeExecutionLimit: value },
         description: `Admin "${actor?.username || 'System'}" changed code execution limit from ${previous?.codeExecutionLimit} to ${value}`,
+        status: 'active',
+        metadata: { ip: req?.ip || null },
+      });
+    }
+
+    return result;
+  }
+
+  // PATCH /settings/disable-speed-challenges → Toggle speed challenges on/off (admin only)
+  @ApiOperation({
+    summary: 'Patch_disable_speed_challenges operation',
+    description: `
+### Required Permissions
+- Admin role
+
+### Example Request
+\`\`\`http
+PATCH /api/settings/disable-speed-challenges HTTP/1.1
+Content-Type: application/json
+
+{
+  "disableSpeedChallenges": true
+}
+\`\`\`
+
+### Example Response
+\`\`\`json
+{
+  "disableSpeedChallenges": true
+}
+\`\`\`
+
+### Test Cases (Working Examples)
+- **Valid Test Case**: Call \`PATCH /api/settings/disable-speed-challenges\` with valid data -> Returns \`200 OK\`.
+- **Invalid Test Case**: Call with malformed data -> Returns \`400 Bad Request\`.
+- **Authentication Test Case**: Call without token -> Returns \`401 Unauthorized\`.
+    `
+  })
+  @ApiResponse({ status: 200, description: 'Successful operation' })
+  @ApiResponse({ status: 400, description: 'Bad Request - Invalid parameters/body' })
+  @ApiResponse({ status: 401, description: 'Unauthorized - Missing or invalid token' })
+  @ApiResponse({ status: 403, description: 'Forbidden - Insufficient permissions' })
+  @Patch('disable-speed-challenges')
+  @UseGuards(AuthGuard('jwt'), RolesGuard)
+  @Roles('Admin')
+  async toggleSpeedChallenges(
+    @Body('disableSpeedChallenges') value: boolean,
+    @CurrentUser() actor: { userId: string; username?: string },
+    @Req() req: any,
+  ) {
+    const previous = await this.settingsService.getSettings() as any;
+    const result = await this.settingsService.updateSettings({ disableSpeedChallenges: value });
+
+    if (previous?.disableSpeedChallenges !== value) {
+      await this.auditLogService.create({
+        actionType: 'FEATURE_FLAG_CHANGED',
+        actor: actor?.username || 'System',
+        actorId: actor?.userId,
+        entityType: 'system',
+        targetId: 'settings',
+        targetLabel: 'Speed Challenges',
+        previousState: { disableSpeedChallenges: previous?.disableSpeedChallenges },
+        newState: { disableSpeedChallenges: value },
+        description: `Admin "${actor?.username || 'System'}" ${value ? 'disabled' : 'enabled'} Speed Challenges`,
         status: 'active',
         metadata: { ip: req?.ip || null },
       });


### PR DESCRIPTION
Introduce a new optional boolean setting disableSpeedChallenges across the app: add it to UpdateSettingsDto, include it in the SettingsSchema with a default of false, and expose a protected PATCH /settings/disable-speed-challenges endpoint. The endpoint requires Admin role (AuthGuard + RolesGuard), updates the setting via settingsService, emits an audit log when the flag changes, and includes Swagger docs and response examples.