### PR TITLE
Remove streak/attempt features, simplify judge/challenge

### DIFF
--- a/src/analytics/analytics.controller.ts
+++ b/src/analytics/analytics.controller.ts
@@ -1,6 +1,5 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, UseGuards } from '@nestjs/common';
 import { AnalyticsService } from './analytics.service';
-import { UseGuards } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { RolesGuard } from '../auth/roles.guard';
 import { Roles } from '../auth/roles.decorator';

--- a/src/analytics/analytics.service.ts
+++ b/src/analytics/analytics.service.ts
@@ -269,6 +269,7 @@ export class AnalyticsService {
             hard: { total: 0, successful: 0, failed: 0, abandoned: 0, successRate: 0 },
             expert: { total: 0, successful: 0, failed: 0, abandoned: 0, successRate: 0 },
         };
+
         for (const item of base.byDifficulty || []) {
             const key = String(item.difficulty || '').toLowerCase();
             if (!response[key]) continue;
@@ -280,6 +281,7 @@ export class AnalyticsService {
                 successRate: Number(item.successRate || 0),
             };
         }
+
         return response;
     }
 
@@ -290,12 +292,12 @@ export class AnalyticsService {
         ]);
 
         const challengeMap = new Map<string, any>();
-        for (const challenge of challenges) {
-            const id = String((challenge as any)._id);
+        for (const challenge of challenges as any[]) {
+            const id = String(challenge._id);
             challengeMap.set(id, {
                 challengeId: id,
-                challengeTitle: (challenge as any).title,
-                difficulty: (challenge as any).difficulty,
+                challengeTitle: challenge.title,
+                difficulty: challenge.difficulty,
                 totalSubmissions: 0,
                 successfulSubmissions: 0,
                 failedSubmissions: 0,
@@ -313,6 +315,7 @@ export class AnalyticsService {
             for (const entry of progressEntries) {
                 const challengeId = String(entry.challengeId || '');
                 if (!challengeMap.has(challengeId)) continue;
+
                 const target = challengeMap.get(challengeId);
                 const submissions = Array.isArray(entry.submissions) ? entry.submissions : [];
 
@@ -359,23 +362,28 @@ export class AnalyticsService {
             }
         }
 
-        const overview = [...challengeMap.values()].map((entry: any) => {
-            const solveStats = solveAccumulator[entry.challengeId];
-            const successRate = entry.totalSubmissions > 0
-                ? this.toTwoDecimals((entry.successfulSubmissions / entry.totalSubmissions) * 100)
-                : 0;
-            const recentSubmissions = entry.recentSubmissions
-                .sort((a: any, b: any) => new Date(b.submittedAt || 0).getTime() - new Date(a.submittedAt || 0).getTime())
-                .slice(0, 10);
-            return {
-                ...entry,
-                successRate,
-                averageSolveTime: solveStats?.count ? this.toTwoDecimals(solveStats.total / solveStats.count) : 0,
-                recentSubmissions,
-            };
-        });
-
-        return overview.sort((a, b) => b.totalSubmissions - a.totalSubmissions);
+        return Array.from(challengeMap.values())
+            .map((challenge) => {
+                const totalSubmissions = challenge.totalSubmissions;
+                const solveStats = solveAccumulator[challenge.challengeId];
+                return {
+                    ...challenge,
+                    successRate: totalSubmissions > 0
+                        ? this.toTwoDecimals((challenge.successfulSubmissions / totalSubmissions) * 100)
+                        : 0,
+                    averageSolveTime: solveStats && solveStats.count > 0
+                        ? this.toTwoDecimals(solveStats.total / solveStats.count)
+                        : 0,
+                    recentSubmissions: challenge.recentSubmissions
+                        .sort((a: any, b: any) => {
+                            const aTime = a.submittedAt ? new Date(a.submittedAt).getTime() : 0;
+                            const bTime = b.submittedAt ? new Date(b.submittedAt).getTime() : 0;
+                            return bTime - aTime;
+                        })
+                        .slice(0, 5),
+                };
+            })
+            .sort((a, b) => b.totalSubmissions - a.totalSubmissions);
     }
 
     async getPlatformInsights() {

--- a/src/auth/jwt.strategy.ts
+++ b/src/auth/jwt.strategy.ts
@@ -1,11 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
-import { UserService } from '../user/user.service';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
-  constructor(private readonly userService: UserService) {
+  constructor() {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
@@ -14,13 +13,6 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   }
 
   async validate(payload: any) {
-    if (payload?.sub) {
-      try {
-        await this.userService.syncDailyStreak(String(payload.sub));
-      } catch {
-        // Streak syncing must never block authentication
-      }
-    }
     return { userId: payload.sub, username: payload.username, role: payload.role };
   }
 }

--- a/src/battles/battle.controller.ts
+++ b/src/battles/battle.controller.ts
@@ -10,16 +10,12 @@ import {
   HttpStatus,
 } from '@nestjs/common';
 import { BattlesService } from './battle.service';
-import { BattleAiService } from './battle-ai.service';
 import { CreateBattleDto } from './dto/create-battle.dto';
 import { UpdateBattleDto } from './dto/update-battle.dto';
 
 @Controller('battles')
 export class BattlesController {
-  constructor(
-    private readonly service: BattlesService,
-    private readonly battleAiService: BattleAiService,
-  ) {}
+  constructor(private readonly service: BattlesService) {}
 
   // POST /battles - Create a new battle
   @Post()
@@ -52,14 +48,5 @@ export class BattlesController {
   @HttpCode(HttpStatus.NO_CONTENT)
   async remove(@Param('id') id: string) {
     await this.service.remove(id);
-  }
-
-  // POST /battles/:id/ai-submit - Generate and submit AI solution
-  @Post(':id/ai-submit')
-  async submitAiSolution(
-    @Param('id') id: string,
-    @Body() body: { language?: 'javascript' | 'python' },
-  ) {
-    return this.battleAiService.submitAiSolution(id, body?.language || 'javascript');
   }
 }

--- a/src/battles/battle.module.ts
+++ b/src/battles/battle.module.ts
@@ -2,11 +2,8 @@ import { Module } from '@nestjs/common';
 import { MongooseModule } from '@nestjs/mongoose';
 import { BattlesController } from './battle.controller';
 import { BattlesService } from './battle.service';
-import { BattleAiService } from './battle-ai.service';
 import { Battle, BattleSchema } from './schemas/battle.schema';
 import { BattleHistory, BattleHistorySchema } from './schemas/battle-history.schema';
-import { ChallengeModule } from '../challenges/challenge.module';
-import { JudgeModule } from '../judge/judge.module';
 
 @Module({
   imports: [
@@ -14,11 +11,9 @@ import { JudgeModule } from '../judge/judge.module';
       { name: Battle.name, schema: BattleSchema },
       { name: BattleHistory.name, schema: BattleHistorySchema },
     ]),
-    ChallengeModule,
-    JudgeModule,
   ],
   controllers: [BattlesController],
-  providers: [BattlesService, BattleAiService],
+  providers: [BattlesService],
   exports: [BattlesService],
 })
 export class BattlesModule {}

--- a/src/challenges/challenge.controller.ts
+++ b/src/challenges/challenge.controller.ts
@@ -240,16 +240,12 @@ Content-Type: application/json
         @Body() dto: CreateChallengeDto,
         @CurrentUser() user: { userId: string; username?: string },
     ) {
-        const result = await this.challengeService.create(
+        const challenge = await this.challengeService.create(
             dto,
             user?.userId,
             user?.username || 'Admin',
         );
-        return {
-            success: true,
-            data: result.challenge,
-            warnings: result.warnings || [],
-        };
+        return { success: true, data: challenge };
     }
 
     /** PATCH /challenges/:id — Update challenge */

--- a/src/challenges/challenge.service.ts
+++ b/src/challenges/challenge.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException, ConflictException } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { Challenge, ChallengeDocument } from './schemas/challenge.schema';
@@ -12,59 +12,10 @@ export class ChallengeService {
         private readonly auditLogService: AuditLogService,
     ) { }
 
-    private normalizeTitle(title: string): string {
-        return (title || '')
-            .toLowerCase()
-            .trim()
-            .replace(/[^\w\s]/g, '')
-            .replace(/\s+/g, ' ');
-    }
-
-    private normalizeDescriptionPrefix(description: string): string {
-        return (description || '')
-            .slice(0, 200)
-            .toLowerCase()
-            .trim()
-            .replace(/[^\w\s]/g, '')
-            .replace(/\s+/g, ' ');
-    }
-
-    private async validateDuplicateChallenge(dto: CreateChallengeDto, ignoreId?: string): Promise<string[]> {
-        const warnings: string[] = [];
-        const title = (dto.title || '').trim();
-        const normalizedTitle = this.normalizeTitle(title);
-
-        const exactTitleMatch = await this.challengeModel.findOne({ title }).lean().exec();
-        if (exactTitleMatch && String((exactTitleMatch as any)._id) !== String(ignoreId || '')) {
-            throw new ConflictException(`A challenge with the title '${title}' already exists. Please use a unique title.`);
-        }
-
-        const normalizedTitleMatch = await this.challengeModel.findOne({ normalizedTitle }).lean().exec();
-        if (normalizedTitleMatch && String((normalizedTitleMatch as any)._id) !== String(ignoreId || '')) {
-            throw new ConflictException(`A challenge with the title '${title}' already exists. Please use a unique title.`);
-        }
-
-        const descriptionPrefix = this.normalizeDescriptionPrefix(dto.description || '');
-        if (descriptionPrefix) {
-            const docs = await this.challengeModel.find({}, { _id: 1, title: 1, description: 1 }).lean().exec();
-            const similar = docs.find((doc: any) => {
-                if (String(doc?._id) === String(ignoreId || '')) return false;
-                return this.normalizeDescriptionPrefix(doc?.description || '') === descriptionPrefix;
-            });
-            if (similar) {
-                warnings.push(`Potential duplicate description detected with "${similar.title}".`);
-            }
-        }
-
-        return warnings;
-    }
-
-    async create(dto: CreateChallengeDto, createdBy?: string, actorName?: string): Promise<{ challenge: ChallengeDocument; warnings: string[] }> {
-        const warnings = await this.validateDuplicateChallenge(dto);
+    async create(dto: CreateChallengeDto, createdBy?: string, actorName?: string): Promise<ChallengeDocument> {
         const challenge = new this.challengeModel({
             ...dto,
             createdBy,
-            normalizedTitle: this.normalizeTitle(dto.title),
             acceptanceRate: 0,
             solvedCount: 0,
         });
@@ -105,7 +56,7 @@ export class ChallengeService {
             });
         }
 
-        return { challenge: saved, warnings };
+        return saved;
     }
 
     async findAll(query?: {
@@ -176,27 +127,9 @@ export class ChallengeService {
     async update(id: string, dto: Partial<CreateChallengeDto>, actorId?: string, actorName?: string): Promise<ChallengeDocument> {
         const existing = await this.challengeModel.findById(id).lean().exec();
         if (!existing) throw new NotFoundException('Challenge not found');
-        if (dto.title || dto.description) {
-            await this.validateDuplicateChallenge(
-                {
-                    ...(existing as any),
-                    ...dto,
-                    title: (dto.title ?? (existing as any).title) as string,
-                    description: (dto.description ?? (existing as any).description) as string,
-                } as CreateChallengeDto,
-                id,
-            );
-        }
 
         const updated = await this.challengeModel
-            .findByIdAndUpdate(
-                id,
-                {
-                    ...dto,
-                    ...(dto.title ? { normalizedTitle: this.normalizeTitle(dto.title) } : {}),
-                },
-                { new: true },
-            )
+            .findByIdAndUpdate(id, dto, { new: true })
             .lean()
             .exec();
         if (!updated) throw new NotFoundException('Challenge not found');

--- a/src/challenges/challenges.service.ts
+++ b/src/challenges/challenges.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException, ConflictException } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { CreateChallengeDto } from './dto/create-challenge.dto';
@@ -11,50 +11,8 @@ export class ChallengesService {
     @InjectModel(Challenge.name) private readonly model: Model<ChallengeDocument>,
   ) {}
 
-  private normalizeTitle(title: string): string {
-    return (title || '')
-      .toLowerCase()
-      .trim()
-      .replace(/[^\w\s]/g, '')
-      .replace(/\s+/g, ' ');
-  }
-
-  private normalizeDescriptionPrefix(description: string): string {
-    return (description || '')
-      .slice(0, 200)
-      .toLowerCase()
-      .trim()
-      .replace(/[^\w\s]/g, '')
-      .replace(/\s+/g, ' ');
-  }
-
-  private async ensureChallengeUniqueness(dto: CreateChallengeDto, ignoreId?: string): Promise<string[]> {
-    const title = (dto.title || '').trim();
-    const normalizedTitle = this.normalizeTitle(title);
-    const exact = await this.model.findOne({ title }).lean().exec();
-    if (exact && String((exact as any)._id) !== String(ignoreId || '')) {
-      throw new ConflictException(`A challenge with the title '${title}' already exists. Please use a unique title.`);
-    }
-    const normalized = await this.model.findOne({ normalizedTitle }).lean().exec();
-    if (normalized && String((normalized as any)._id) !== String(ignoreId || '')) {
-      throw new ConflictException(`A challenge with the title '${title}' already exists. Please use a unique title.`);
-    }
-    const descriptionPrefix = this.normalizeDescriptionPrefix(dto.description || '');
-    if (!descriptionPrefix) return [];
-    const docs = await this.model.find({}, { _id: 1, title: 1, description: 1 }).lean().exec();
-    const similar = docs.find((doc: any) => {
-      if (String(doc?._id) === String(ignoreId || '')) return false;
-      return this.normalizeDescriptionPrefix(doc?.description || '') === descriptionPrefix;
-    });
-    return similar ? [`Potential duplicate description detected with "${similar.title}".`] : [];
-  }
-
   async create(dto: CreateChallengeDto): Promise<Challenge> {
-    await this.ensureChallengeUniqueness(dto);
-    const created = new this.model({
-      ...dto,
-      normalizedTitle: this.normalizeTitle(dto.title),
-    });
+    const created = new this.model(dto);
     return created.save();
   }
 
@@ -81,24 +39,7 @@ export class ChallengesService {
   }
 
   async update(id: string, dto: UpdateChallengeDto): Promise<Challenge> {
-    if (dto.title || dto.description) {
-      const existing = await this.model.findById(id).lean().exec();
-      if (!existing) throw new NotFoundException(`Challenge with id ${id} not found`);
-      await this.ensureChallengeUniqueness({
-        ...(existing as any),
-        ...dto,
-        title: (dto.title ?? (existing as any).title) as string,
-        description: (dto.description ?? (existing as any).description) as string,
-      } as CreateChallengeDto, id);
-    }
-    const updated = await this.model.findByIdAndUpdate(
-      id,
-      {
-        ...dto,
-        ...(dto.title ? { normalizedTitle: this.normalizeTitle(dto.title) } : {}),
-      },
-      { new: true },
-    ).exec();
+    const updated = await this.model.findByIdAndUpdate(id, dto, { new: true }).exec();
     if (!updated) throw new NotFoundException(`Challenge with id ${id} not found`);
     return updated;
   }

--- a/src/challenges/schemas/challenge.schema.ts
+++ b/src/challenges/schemas/challenge.schema.ts
@@ -5,11 +5,8 @@ export type ChallengeDocument = Challenge & Document;
 
 @Schema({ timestamps: true })
 export class Challenge {
-    @Prop({ required: true, unique: true, trim: true })
+    @Prop({ required: true })
     title: string;
-
-    @Prop({ required: true, unique: true, index: true })
-    normalizedTitle: string;
 
     @Prop({ required: true, enum: ['Easy', 'Medium', 'Hard', 'Expert'] })
     difficulty: string;
@@ -68,23 +65,8 @@ export class Challenge {
 
 export const ChallengeSchema = SchemaFactory.createForClass(Challenge);
 
-const normalizeTitle = (value: string) =>
-    (value || '')
-        .toLowerCase()
-        .trim()
-        .replace(/[^\w\s]/g, '')
-        .replace(/\s+/g, ' ');
-
-ChallengeSchema.pre('validate', function setNormalizedTitle(next) {
-    const current = this as any;
-    current.normalizedTitle = normalizeTitle(current.title || '');
-    next();
-});
-
 // Performance Indexes for backend querying
 ChallengeSchema.index({ status: 1, difficulty: 1 });
 ChallengeSchema.index({ tags: 1 });
 ChallengeSchema.index({ createdAt: -1 });
-ChallengeSchema.index({ title: 1 }, { unique: true });
-ChallengeSchema.index({ normalizedTitle: 1 }, { unique: true });
 ChallengeSchema.index({ title: 'text', description: 'text', tags: 'text' });

--- a/src/judge/judge.module.ts
+++ b/src/judge/judge.module.ts
@@ -9,7 +9,6 @@ import { UserModule } from '../user/user.module';
 import { AuditLogModule } from '../audit-logs/audit-log.module';
 import { SandboxAdminController } from './sandbox-admin.controller';
 import { SandboxMetricSchema } from './schemas/sandbox-metric.schema';
-import { ChallengeAttemptController } from './challenge-attempt.controller';
 
 @Module({
   imports: [
@@ -19,7 +18,7 @@ import { ChallengeAttemptController } from './challenge-attempt.controller';
     MongooseModule.forFeature([{ name: 'SandboxMetric', schema: SandboxMetricSchema }]),
   ],
   providers: [JudgeService, DockerExecutionService, AIAnalysisService],
-  controllers: [JudgeController, SandboxAdminController, ChallengeAttemptController],
-  exports: [JudgeService, DockerExecutionService, AIAnalysisService],
+  controllers: [JudgeController, SandboxAdminController],
+  exports: [JudgeService, DockerExecutionService],
 })
 export class JudgeModule {}

--- a/src/judge/judge.service.ts
+++ b/src/judge/judge.service.ts
@@ -17,129 +17,6 @@ export class JudgeService {
     private readonly auditLogService: AuditLogService,
   ) {}
 
-  async startChallengeAttempt(userId: string, challengeId: string, ipAddress?: string | null) {
-    const challenge = await this.challengeService.findById(challengeId);
-    const userProfile: any = await this.userService.findOne(userId).catch(() => null);
-    const actorName = userProfile?.username || `user:${userId}`;
-
-    const attempt = await this.userService.startChallengeAttempt(userId, challengeId);
-    await this.auditLogService.create({
-      actionType: 'CHALLENGE_STARTED',
-      actor: actorName,
-      actorId: userId,
-      entityType: 'challenge',
-      targetId: challengeId,
-      targetLabel: challenge.title,
-      description: `${actorName} started challenge "${challenge.title}" (${challenge.difficulty})`,
-      status: 'active',
-      metadata: {
-        difficulty: challenge.difficulty,
-        ipAddress: ipAddress || null,
-        attemptId: attempt.attemptId,
-      },
-    });
-    return attempt;
-  }
-
-  async leaveChallengeAttempt(
-    userId: string,
-    challengeId: string,
-    reason: 'left_page' | 'tab_closed' = 'left_page',
-    ipAddress?: string | null,
-  ) {
-    const challenge = await this.challengeService.findById(challengeId);
-    const userProfile: any = await this.userService.findOne(userId).catch(() => null);
-    const actorName = userProfile?.username || `user:${userId}`;
-
-    const result = await this.userService.leaveChallengeAttempt(userId, challengeId, reason);
-    await this.auditLogService.create({
-      actionType: 'CHALLENGE_ABANDONED',
-      actor: actorName,
-      actorId: userId,
-      entityType: 'challenge',
-      targetId: challengeId,
-      targetLabel: challenge.title,
-      description: `${actorName} left challenge "${challenge.title}" and entered grace period`,
-      status: 'active',
-      metadata: {
-        difficulty: challenge.difficulty,
-        ipAddress: ipAddress || null,
-        reason,
-        gracePeriodExpiresAt: result.gracePeriodExpiresAt,
-      },
-    });
-    return result;
-  }
-
-  async returnChallengeAttempt(userId: string, challengeId: string, ipAddress?: string | null) {
-    const challenge = await this.challengeService.findById(challengeId).catch(() => null);
-    const userProfile: any = await this.userService.findOne(userId).catch(() => null);
-    const actorName = userProfile?.username || `user:${userId}`;
-
-    const result = await this.userService.returnChallengeAttempt(userId, challengeId);
-    if (challenge) {
-      await this.auditLogService.create({
-        actionType: result.allowed ? 'CHALLENGE_STARTED' : 'CHALLENGE_ABANDONED',
-        actor: actorName,
-        actorId: userId,
-        entityType: 'challenge',
-        targetId: challengeId,
-        targetLabel: challenge.title,
-        description: result.allowed
-          ? `${actorName} returned to challenge "${challenge.title}" within grace period`
-          : `${actorName} failed to return to challenge "${challenge.title}" before grace period expiration`,
-        status: 'active',
-        metadata: {
-          difficulty: challenge.difficulty,
-          ipAddress: ipAddress || null,
-          allowed: result.allowed,
-          remainingTime: result.remainingTime,
-          status: result.status,
-        },
-      });
-    }
-
-    return {
-      ...result,
-      remainingSeconds: Number(result?.remainingTime || 0),
-    };
-  }
-
-  async expireChallengeAttempt(userId: string, challengeId: string) {
-    return this.userService.expireChallengeAttempt(userId, challengeId);
-  }
-
-  async abandonChallengeAttempt(
-    userId: string,
-    challengeId: string,
-    reason: 'timeout' | 'left_page' | 'tab_closed' = 'timeout',
-    ipAddress?: string | null,
-  ) {
-    const challenge = await this.challengeService.findById(challengeId).catch(() => null);
-    const userProfile: any = await this.userService.findOne(userId).catch(() => null);
-    const actorName = userProfile?.username || `user:${userId}`;
-    const result = await this.userService.abandonChallengeAttempt(userId, challengeId, reason);
-
-    if (challenge) {
-      await this.auditLogService.create({
-        actionType: 'CHALLENGE_ABANDONED',
-        actor: actorName,
-        actorId: userId,
-        entityType: 'challenge',
-        targetId: challengeId,
-        targetLabel: challenge.title,
-        description: `${actorName} abandoned challenge "${challenge.title}" (${challenge.difficulty})`,
-        status: 'active',
-        metadata: {
-          difficulty: challenge.difficulty,
-          reason,
-          ipAddress: ipAddress || null,
-        },
-      });
-    }
-    return result;
-  }
-
   async judgeSubmission(
     userId: string,
     challengeId: string,
@@ -488,14 +365,6 @@ export class JudgeService {
         solveTimeSeconds: entry.solveTimeSeconds ?? null,
         xpAwarded: Number(entry.xpAwarded || 0),
         solvedAt: entry.solvedAt || null,
-        attemptId: entry.attemptId || null,
-        attemptStatus: entry.attemptStatus || 'completed',
-        attemptStartedAt: entry.attemptStartedAt || null,
-        leftAt: entry.leftAt || null,
-        gracePeriodExpiresAt: entry.gracePeriodExpiresAt || null,
-        returnedAt: entry.returnedAt || null,
-        abandonmentReason: entry.abandonmentReason || null,
-        incompleteAttemptCount: Number(entry.incompleteAttemptCount || 0),
         latestSubmission: Array.isArray(entry.submissions) && entry.submissions.length
           ? entry.submissions[entry.submissions.length - 1]
           : null,
@@ -512,7 +381,6 @@ export class JudgeService {
     ipAddress?: string | null,
     logStart = false,
   ) {
-    await this.userService.expireChallengeAttempt(userId, challengeId);
     const challenge = await this.challengeService.findById(challengeId).catch(() => null);
     const userProfile: any = await this.userService.findOne(userId).catch(() => null);
     const actorName = userProfile?.username || `user:${userId}`;
@@ -553,14 +421,6 @@ export class JudgeService {
       solveTimeSeconds: entry.solveTimeSeconds ?? null,
       xpAwarded: Number(entry.xpAwarded || 0),
       solvedAt: entry.solvedAt || null,
-      attemptId: entry.attemptId || null,
-      attemptStatus: entry.attemptStatus || 'completed',
-      attemptStartedAt: entry.attemptStartedAt || null,
-      leftAt: entry.leftAt || null,
-      gracePeriodExpiresAt: entry.gracePeriodExpiresAt || null,
-      returnedAt: entry.returnedAt || null,
-      abandonmentReason: entry.abandonmentReason || null,
-      incompleteAttemptCount: Number(entry.incompleteAttemptCount || 0),
       submissions: Array.isArray(entry.submissions) ? entry.submissions : [],
     };
   }

--- a/src/judge/services/ai-analysis.service.ts
+++ b/src/judge/services/ai-analysis.service.ts
@@ -117,13 +117,9 @@ export class AIAnalysisService {
       });
       const raw = completion.choices[0].message.content;
       const parsed = JSON.parse(raw || '{}') as any;
-      const parsedTime = parsed?.timeComplexity;
-      const parsedSpace = parsed?.spaceComplexity;
-      const safeTime = !parsedTime || parsedTime === 'Unknown' ? fallback.timeComplexity : parsedTime;
-      const safeSpace = !parsedSpace || parsedSpace === 'Unknown' ? fallback.spaceComplexity : parsedSpace;
       return {
-        timeComplexity: safeTime,
-        spaceComplexity: safeSpace,
+        timeComplexity: parsed?.timeComplexity || fallback.timeComplexity,
+        spaceComplexity: parsed?.spaceComplexity || fallback.spaceComplexity,
         aiDetection: parsed?.aiDetection === 'AI_SUSPECTED' ? 'AI_SUSPECTED' : 'MANUAL',
         recommendations: Array.isArray(parsed?.recommendations) && parsed.recommendations.length
           ? parsed.recommendations.slice(0, 5).map((item: any) => String(item))

--- a/src/user/schemas/user.schema.ts
+++ b/src/user/schemas/user.schema.ts
@@ -22,11 +22,6 @@ export const UserSchema = new Schema(
     xp: { type: Number, default: 0 },
     level: { type: String, default: null },
     streak: { type: Number, default: 0 },
-    currentStreak: { type: Number, default: 0 },
-    longestStreak: { type: Number, default: 0 },
-    lastLoginDate: { type: Date, default: null },
-    streakUpdatedAt: { type: Date, default: null },
-    loginActivityDates: { type: [String], default: [] },
     // Generated placement problems (stored at registration)
     placementProblems: { type: Array, default: [] },
     challengeProgress: {
@@ -38,18 +33,6 @@ export const UserSchema = new Schema(
           solveTimeSeconds: { type: Number, default: null },
           xpAwarded: { type: Number, default: 0 },
           solvedAt: { type: Date, default: null },
-          attemptId: { type: String, default: null },
-          attemptStatus: {
-            type: String,
-            enum: ['in_progress', 'completed', 'abandoned', 'grace_period'],
-            default: 'completed',
-          },
-          attemptStartedAt: { type: Date, default: null },
-          leftAt: { type: Date, default: null },
-          gracePeriodExpiresAt: { type: Date, default: null },
-          returnedAt: { type: Date, default: null },
-          abandonmentReason: { type: String, enum: ['left_page', 'timeout', 'tab_closed', null], default: null },
-          incompleteAttemptCount: { type: Number, default: 0 },
           submissions: {
             type: [
               {

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -156,32 +156,6 @@ Authenticated user (JWT required)
 	@UseGuards(JwtAuthGuard)
 	@ApiBearerAuth()
 	@ApiOperation({
-		summary: 'Get my daily streak',
-		description: 'Returns current streak, longest streak, last login date, motivational streak message, and 7-day activity markers.',
-	})
-	@ApiResponse({ status: 200, description: 'Streak returned successfully' })
-	@Get('me/streak')
-	async getMyStreak(@CurrentUser() user: { userId: string }) {
-		return this.userService.getStreak(user.userId);
-	}
-
-	@UseGuards(JwtAuthGuard)
-	@ApiBearerAuth()
-	@Get('streak')
-	async getStreak(@CurrentUser() user: { userId: string }) {
-		return this.userService.getStreak(user.userId);
-	}
-
-	@UseGuards(JwtAuthGuard)
-	@ApiBearerAuth()
-	@Get('attempts')
-	async getMyAttempts(@CurrentUser() user: { userId: string }) {
-		return this.userService.getUserAttempts(user.userId);
-	}
-
-	@UseGuards(JwtAuthGuard)
-	@ApiBearerAuth()
-	@ApiOperation({
 		summary: 'Update my XP (and auto-update rank)',
 		description: `
 Adds or subtracts XP from the authenticated user. Rank is automatically recalculated.

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -27,53 +27,6 @@ export const RANK_THRESHOLDS: Record<string, number> = {
 };
 
 const RANK_ORDER = ['BRONZE', 'SILVER', 'GOLD', 'PLATINUM', 'DIAMOND'];
-const STREAK_ACTIVITY_WINDOW_DAYS = 30;
-const GRACE_PERIOD_SECONDS = 120;
-
-const STREAK_MESSAGES = {
-  dayOne: [
-    "Welcome back, warrior! Every legend starts with Day 1. Let's build something unstoppable. \u{1F525}",
-    "Day 1 � The grind begins NOW. Show these algorithms who's boss! \u{1F4AA}",
-    "Fresh start, fresh fire. Your coding journey resets today. Make it count! \u{1F680}",
-    'Day 1 locked in. One solid session today can change your entire trajectory. \u{2B50}',
-    "A new streak starts today. Keep showing up and you'll shock yourself in a week. \u{1F947}",
-  ],
-  buildMomentum: [
-    "Day {streak} � You're building momentum! Keep this energy going and watch your skills skyrocket! \u{26A1}",
-    "{streak} days strong! The consistency is starting to show. Don't stop now! \u{1F525}",
-    "Look at you � {streak} days in a row! Most people quit by now. You're different. \u{1F48E}",
-    'Momentum unlocked: Day {streak}. Keep stacking wins and let discipline do the heavy lifting. \u{26A1}',
-    '{streak} straight days! Small daily reps are turning you into a serious problem-solver. \u{1F680}',
-  ],
-  beastMode: [
-    "\u{1F525} {streak}-DAY STREAK! You're officially in beast mode. The algorithms fear you!",
-    "{streak} consecutive days! You're not just practicing � you're transforming into a coding machine! \u{26A1}",
-    "UNSTOPPABLE! {streak} days and counting. At this rate, you'll be solving problems in your sleep! \u{1F4AA}",
-    '{streak} days with no excuses. That is elite focus and it is paying off. \u{1F3C6}',
-    'Day {streak}. You are building a reputation with yourself for not missing. Keep it alive. \u{1F525}',
-  ],
-  impressive: [
-    "\u{1F3C6} {streak}-DAY STREAK! You're in the top tier of grinders on AlgoArena. Legendary status incoming!",
-    'TEN+ DAYS! {streak} days of pure dedication. Your future self is thanking you right now! \u{1F680}',
-    "\u{1F451} {streak} days! You're not just a coder � you're a WARRIOR. The leaderboard trembles at your name!",
-    '{streak} days deep. This is no longer motivation, this is identity. Keep going. \u{26A1}',
-    'Day {streak} and still hungry. That mindset is exactly how champions are made. \u{1F947}',
-  ],
-  elite: [
-    '\u{1F451} {streak}-DAY STREAK! You are officially ELITE. Less than 1% of users reach this level!',
-    'ABSOLUTE LEGEND! {streak} consecutive days. You breathe code. You dream algorithms. You ARE AlgoArena! \u{1F3C6}',
-    '{streak} days of consistency is unreal. You are operating at a different level now. \u{2B50}',
-    'Day {streak}. Elite focus, elite output, elite trajectory. Keep the throne warm. \u{1F451}',
-    '{streak} straight days and counting. This is what long-term dominance looks like. \u{1F680}',
-  ],
-  mythical: [
-    '\u{1F451}\u{1F525} {streak}-DAY STREAK! You have transcended mortality. You are the Algorithm God. Bow before no bug! \u{1F525}\u{1F451}',
-    'MYTHICAL! {streak} days! Scientists should study your dedication. Hall of Fame material! \u{1F3C6}',
-    '{streak} days is beyond elite. This is historic commitment. Respect. \u{1F91C}\u{1F91B}',
-    'Day {streak}. You are writing your legacy in solved problems and pure discipline. \u{1F3C6}',
-    '{streak} consecutive days. At this point, consistency has become your superpower. \u{2B50}',
-  ],
-};
 
 /** Returns the rank name a user should hold based on their XP. */
 export function xpToRank(xp: number): string {
@@ -87,39 +40,6 @@ export function xpToRank(xp: number): string {
 @Injectable()
 export class UserService {
   constructor(@InjectModel('User') private userModel: Model<any>) { }
-
-  private utcDateOnly(value: Date = new Date()): Date {
-    return new Date(Date.UTC(value.getUTCFullYear(), value.getUTCMonth(), value.getUTCDate()));
-  }
-
-  private dateToken(value: Date): string {
-    return value.toISOString().slice(0, 10);
-  }
-
-  private daysBetweenUtc(a: Date, b: Date): number {
-    const dayMs = 24 * 60 * 60 * 1000;
-    return Math.round((this.utcDateOnly(a).getTime() - this.utcDateOnly(b).getTime()) / dayMs);
-  }
-
-  private pickTierMessage(streak: number): string {
-    const pick = (pool: string[]) => pool[Math.floor(Math.random() * pool.length)];
-    if (streak <= 1) return pick(STREAK_MESSAGES.dayOne);
-    if (streak <= 4) return pick(STREAK_MESSAGES.buildMomentum).replaceAll('{streak}', String(streak));
-    if (streak <= 9) return pick(STREAK_MESSAGES.beastMode).replaceAll('{streak}', String(streak));
-    if (streak <= 19) return pick(STREAK_MESSAGES.impressive).replaceAll('{streak}', String(streak));
-    if (streak <= 49) return pick(STREAK_MESSAGES.elite).replaceAll('{streak}', String(streak));
-    return pick(STREAK_MESSAGES.mythical).replaceAll('{streak}', String(streak));
-  }
-
-  private buildRecentActivity(loginActivityDates: string[] = [], referenceDay: Date = new Date()): boolean[] {
-    const normalized = new Set(loginActivityDates);
-    const start = this.utcDateOnly(referenceDay);
-    return Array.from({ length: 7 }, (_, index) => {
-      const day = new Date(start);
-      day.setUTCDate(start.getUTCDate() - (6 - index));
-      return normalized.has(this.dateToken(day));
-    });
-  }
 
   private ensureValidObjectId(id: string) {
     if (!id || !/^[a-fA-F0-9]{24}$/.test(id) || !Types.ObjectId.isValid(id)) {
@@ -184,86 +104,6 @@ export class UserService {
     return rest;
   }
 
-  async syncDailyStreak(userId: string): Promise<{
-    currentStreak: number;
-    longestStreak: number;
-    lastLoginDate: string;
-    streakMessage: string;
-    recentActivity: boolean[];
-  }> {
-    this.ensureValidObjectId(userId);
-    const now = new Date();
-    const today = this.utcDateOnly(now);
-    const todayToken = this.dateToken(today);
-
-    const user = await this.userModel.findById(userId).lean().exec() as any;
-    if (!user) throw new NotFoundException('User not found');
-
-    const lastLoginDateRaw = user.lastLoginDate ? new Date(user.lastLoginDate) : null;
-    const lastLoginDay = lastLoginDateRaw ? this.utcDateOnly(lastLoginDateRaw) : null;
-    const previousCurrent = Number(user.currentStreak ?? user.streak ?? 0);
-    const previousLongest = Number(user.longestStreak ?? user.streak ?? 0);
-    const loginActivityDates = Array.isArray(user.loginActivityDates) ? [...user.loginActivityDates] : [];
-
-    let currentStreak = previousCurrent;
-    let longestStreak = previousLongest;
-    let shouldPersist = false;
-
-    if (!lastLoginDay) {
-      currentStreak = 1;
-      longestStreak = Math.max(longestStreak, 1);
-      shouldPersist = true;
-    } else {
-      const diffDays = this.daysBetweenUtc(today, lastLoginDay);
-      if (diffDays === 0) {
-        // already counted today
-      } else if (diffDays === 1) {
-        currentStreak = previousCurrent + 1;
-        longestStreak = Math.max(longestStreak, currentStreak);
-        shouldPersist = true;
-      } else if (diffDays > 1) {
-        currentStreak = 1;
-        longestStreak = Math.max(longestStreak, previousCurrent, previousLongest, 1);
-        shouldPersist = true;
-      }
-    }
-
-    const nextActivitySet = new Set(loginActivityDates);
-    nextActivitySet.add(todayToken);
-    const nextActivity = [...nextActivitySet]
-      .sort((a, b) => (a < b ? -1 : 1))
-      .slice(-STREAK_ACTIVITY_WINDOW_DAYS);
-
-    if (shouldPersist || !loginActivityDates.includes(todayToken)) {
-      await this.userModel.findByIdAndUpdate(
-        userId,
-        {
-          currentStreak,
-          longestStreak,
-          streak: currentStreak,
-          lastLoginDate: today,
-          streakUpdatedAt: now,
-          loginActivityDates: nextActivity,
-        },
-      ).exec();
-    } else if (Number(user.streak ?? 0) !== currentStreak) {
-      await this.userModel.findByIdAndUpdate(userId, { streak: currentStreak }).exec();
-    }
-
-    return {
-      currentStreak,
-      longestStreak,
-      lastLoginDate: today.toISOString(),
-      streakMessage: this.pickTierMessage(currentStreak),
-      recentActivity: this.buildRecentActivity(nextActivity, now),
-    };
-  }
-
-  async getStreak(userId: string) {
-    const synced = await this.syncDailyStreak(userId);
-    return synced;
-  }
-
   // ── Rank & XP Stats ───────────────────────────────────────────────────────
 
   /**
@@ -287,7 +127,7 @@ export class UserService {
 
     const xp: number = user.xp ?? 0;
     const rank: string | null = user.rank ?? null;
-    const streak: number = user.currentStreak ?? user.streak ?? 0;
+    const streak: number = user.streak ?? 0;
 
     // No rank yet (pre-placement)
     if (!rank) {
@@ -359,211 +199,6 @@ export class UserService {
     return progress.find((entry: any) => entry.challengeId === challengeId) || null;
   }
 
-  private createDefaultProgressEntry(challengeId: string) {
-    return {
-      challengeId,
-      status: 'UNSOLVED',
-      failedAttempts: 0,
-      solveTimeSeconds: null,
-      xpAwarded: 0,
-      solvedAt: null,
-      attemptId: null,
-      attemptStatus: 'completed',
-      attemptStartedAt: null,
-      leftAt: null,
-      gracePeriodExpiresAt: null,
-      returnedAt: null,
-      abandonmentReason: null,
-      incompleteAttemptCount: 0,
-      submissions: [],
-    };
-  }
-
-  async startChallengeAttempt(userId: string, challengeId: string) {
-    this.ensureValidObjectId(userId);
-    const user = await this.userModel.findById(userId).lean().exec() as any;
-    if (!user) throw new NotFoundException('User not found');
-
-    const challengeProgress = Array.isArray(user.challengeProgress) ? [...user.challengeProgress] : [];
-    const index = challengeProgress.findIndex((entry: any) => entry.challengeId === challengeId);
-    const existing = index >= 0 ? challengeProgress[index] : this.createDefaultProgressEntry(challengeId);
-
-    const now = new Date();
-    const attemptId = `${challengeId}-${now.getTime()}`;
-    const nextEntry = {
-      ...existing,
-      attemptId,
-      attemptStatus: existing.status === 'SOLVED' ? 'completed' : 'in_progress',
-      attemptStartedAt: now,
-      leftAt: null,
-      gracePeriodExpiresAt: null,
-      returnedAt: null,
-      abandonmentReason: null,
-    };
-
-    if (index >= 0) challengeProgress[index] = nextEntry;
-    else challengeProgress.push(nextEntry);
-
-    await this.userModel.findByIdAndUpdate(userId, { challengeProgress }).exec();
-    return {
-      challengeId,
-      attemptId,
-      startedAt: now.toISOString(),
-      status: nextEntry.attemptStatus,
-    };
-  }
-
-  async leaveChallengeAttempt(userId: string, challengeId: string, reason: 'left_page' | 'tab_closed' = 'left_page') {
-    this.ensureValidObjectId(userId);
-    const user = await this.userModel.findById(userId).lean().exec() as any;
-    if (!user) throw new NotFoundException('User not found');
-
-    const challengeProgress = Array.isArray(user.challengeProgress) ? [...user.challengeProgress] : [];
-    const index = challengeProgress.findIndex((entry: any) => entry.challengeId === challengeId);
-    const existing = index >= 0 ? challengeProgress[index] : this.createDefaultProgressEntry(challengeId);
-    const now = new Date();
-    const currentGraceExpiry = existing.gracePeriodExpiresAt ? new Date(existing.gracePeriodExpiresAt) : null;
-    const isExistingGraceStillValid = currentGraceExpiry && currentGraceExpiry.getTime() > now.getTime();
-    const expiresAt = isExistingGraceStillValid
-      ? currentGraceExpiry
-      : new Date(now.getTime() + GRACE_PERIOD_SECONDS * 1000);
-
-    const nextEntry = {
-      ...existing,
-      attemptStatus: existing.status === 'SOLVED' ? 'completed' : 'grace_period',
-      leftAt: now,
-      gracePeriodExpiresAt: existing.status === 'SOLVED' ? null : expiresAt,
-      abandonmentReason: reason,
-      attemptStartedAt: existing.attemptStartedAt || now,
-    };
-
-    if (index >= 0) challengeProgress[index] = nextEntry;
-    else challengeProgress.push(nextEntry);
-
-    await this.userModel.findByIdAndUpdate(userId, { challengeProgress }).exec();
-    return {
-      challengeId,
-      status: nextEntry.attemptStatus,
-      gracePeriodExpiresAt: nextEntry.gracePeriodExpiresAt?.toISOString?.() || null,
-    };
-  }
-
-  async abandonChallengeAttempt(userId: string, challengeId: string, reason: 'timeout' | 'left_page' | 'tab_closed' = 'timeout') {
-    this.ensureValidObjectId(userId);
-    const user = await this.userModel.findById(userId).lean().exec() as any;
-    if (!user) throw new NotFoundException('User not found');
-    const challengeProgress = Array.isArray(user.challengeProgress) ? [...user.challengeProgress] : [];
-    const index = challengeProgress.findIndex((entry: any) => entry.challengeId === challengeId);
-    const existing = index >= 0 ? challengeProgress[index] : this.createDefaultProgressEntry(challengeId);
-    const nextEntry = {
-      ...existing,
-      attemptStatus: existing.status === 'SOLVED' ? 'completed' : 'abandoned',
-      abandonmentReason: existing.status === 'SOLVED' ? null : reason,
-      leftAt: existing.leftAt || new Date(),
-      gracePeriodExpiresAt: existing.gracePeriodExpiresAt || new Date(),
-      incompleteAttemptCount: existing.status === 'SOLVED'
-        ? Number(existing.incompleteAttemptCount || 0)
-        : Number(existing.incompleteAttemptCount || 0) + 1,
-    };
-    if (index >= 0) challengeProgress[index] = nextEntry;
-    else challengeProgress.push(nextEntry);
-    await this.userModel.findByIdAndUpdate(userId, { challengeProgress }).exec();
-    return {
-      challengeId,
-      status: nextEntry.attemptStatus,
-      abandonmentReason: nextEntry.abandonmentReason,
-    };
-  }
-
-  async returnChallengeAttempt(userId: string, challengeId: string) {
-    this.ensureValidObjectId(userId);
-    const user = await this.userModel.findById(userId).lean().exec() as any;
-    if (!user) throw new NotFoundException('User not found');
-
-    const challengeProgress = Array.isArray(user.challengeProgress) ? [...user.challengeProgress] : [];
-    const index = challengeProgress.findIndex((entry: any) => entry.challengeId === challengeId);
-    const existing = index >= 0 ? challengeProgress[index] : this.createDefaultProgressEntry(challengeId);
-    const now = new Date();
-    const expiresAt = existing.gracePeriodExpiresAt ? new Date(existing.gracePeriodExpiresAt) : null;
-
-    if (existing.status === 'SOLVED') {
-      return { allowed: false, remainingTime: 0, status: 'completed' };
-    }
-
-    if (!expiresAt || now.getTime() > expiresAt.getTime()) {
-      const nextEntry = {
-        ...existing,
-        attemptStatus: 'abandoned',
-        abandonmentReason: 'timeout',
-        gracePeriodExpiresAt: expiresAt || now,
-        incompleteAttemptCount: Number(existing.incompleteAttemptCount || 0) + 1,
-      };
-      if (index >= 0) challengeProgress[index] = nextEntry;
-      else challengeProgress.push(nextEntry);
-      await this.userModel.findByIdAndUpdate(userId, { challengeProgress }).exec();
-      return { allowed: false, remainingTime: 0, status: 'abandoned' };
-    }
-
-    const remainingTime = Math.max(0, Math.floor((expiresAt.getTime() - now.getTime()) / 1000));
-    const nextEntry = {
-      ...existing,
-      attemptStatus: 'in_progress',
-      returnedAt: now,
-      leftAt: null,
-      gracePeriodExpiresAt: expiresAt,
-      abandonmentReason: null,
-      attemptStartedAt: existing.attemptStartedAt || now,
-    };
-    if (index >= 0) challengeProgress[index] = nextEntry;
-    else challengeProgress.push(nextEntry);
-    await this.userModel.findByIdAndUpdate(userId, { challengeProgress }).exec();
-    return { allowed: true, remainingTime, status: 'in_progress' };
-  }
-
-  async expireChallengeAttempt(userId: string, challengeId: string) {
-    this.ensureValidObjectId(userId);
-    const user = await this.userModel.findById(userId).lean().exec() as any;
-    if (!user) throw new NotFoundException('User not found');
-    const challengeProgress = Array.isArray(user.challengeProgress) ? [...user.challengeProgress] : [];
-    const index = challengeProgress.findIndex((entry: any) => entry.challengeId === challengeId);
-    if (index < 0) return { updated: false, status: 'UNSOLVED' };
-
-    const existing = challengeProgress[index];
-    const expiresAt = existing.gracePeriodExpiresAt ? new Date(existing.gracePeriodExpiresAt) : null;
-    if (existing.attemptStatus !== 'grace_period' || !expiresAt || Date.now() <= expiresAt.getTime()) {
-      return { updated: false, status: existing.attemptStatus || 'completed' };
-    }
-
-    challengeProgress[index] = {
-      ...existing,
-      attemptStatus: 'abandoned',
-      abandonmentReason: 'timeout',
-      incompleteAttemptCount: Number(existing.incompleteAttemptCount || 0) + 1,
-    };
-    await this.userModel.findByIdAndUpdate(userId, { challengeProgress }).exec();
-    return { updated: true, status: 'abandoned' };
-  }
-
-  async getUserAttempts(userId: string) {
-    this.ensureValidObjectId(userId);
-    const user = await this.userModel.findById(userId).lean().exec() as any;
-    if (!user) throw new NotFoundException('User not found');
-    const progress = Array.isArray(user.challengeProgress) ? user.challengeProgress : [];
-    return progress.map((entry: any) => ({
-      challengeId: entry.challengeId,
-      status: entry.status || 'UNSOLVED',
-      attemptId: entry.attemptId || null,
-      attemptStatus: entry.attemptStatus || 'completed',
-      attemptStartedAt: entry.attemptStartedAt || null,
-      leftAt: entry.leftAt || null,
-      gracePeriodExpiresAt: entry.gracePeriodExpiresAt || null,
-      returnedAt: entry.returnedAt || null,
-      abandonmentReason: entry.abandonmentReason || null,
-      incompleteAttemptCount: Number(entry.incompleteAttemptCount || 0),
-      solvedAt: entry.solvedAt || null,
-    }));
-  }
-
   async recordChallengeSubmission(
     userId: string,
     challengeId: string,
@@ -578,7 +213,15 @@ export class UserService {
     const index = challengeProgress.findIndex((entry: any) => entry.challengeId === challengeId);
     const existing = index >= 0 ? challengeProgress[index] : null;
 
-    const baseEntry = existing || this.createDefaultProgressEntry(challengeId);
+    const baseEntry = existing || {
+      challengeId,
+      status: 'UNSOLVED',
+      failedAttempts: 0,
+      solveTimeSeconds: null,
+      xpAwarded: 0,
+      solvedAt: null,
+      submissions: [],
+    };
 
     const submissions = Array.isArray(baseEntry.submissions) ? [...baseEntry.submissions, submission] : [submission];
     let nextStatus = baseEntry.status || 'UNSOLVED';
@@ -608,12 +251,6 @@ export class UserService {
       solveTimeSeconds,
       xpAwarded,
       solvedAt,
-      attemptStatus: submission.passed ? 'completed' : 'in_progress',
-      attemptStartedAt: baseEntry.attemptStartedAt || new Date(),
-      leftAt: null,
-      gracePeriodExpiresAt: null,
-      returnedAt: submission.passed ? new Date() : baseEntry.returnedAt || null,
-      abandonmentReason: null,
       submissions,
       lastSubmittedAt: new Date(),
     };
@@ -881,5 +518,3 @@ export class UserService {
     ).exec();
   }
 }
-
-

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -4,6 +4,11 @@
   "testEnvironment": "node",
   "testRegex": ".e2e-spec.ts$",
   "transform": {
-    "^.+\\.(t|j)s$": "ts-jest"
+    "^.+\\.(t|j)s$": [
+      "ts-jest",
+      {
+        "tsconfig": "<rootDir>/../tsconfig.spec.json"
+      }
+    ]
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "resolvePackageJsonExports": false,
-    "types": ["node", "jest"],
+    "types": ["node"],
     "esModuleInterop": true,
     "isolatedModules": true,
     "declaration": true,

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["node", "jest"]
+  },
+  "include": ["src/**/*.spec.ts", "src/**/*.test.ts", "test/**/*.ts"]
+}


### PR DESCRIPTION
Remove user streak and attempt lifecycle logic, simplify challenge uniqueness and schema, and trim judge/battle AI integrations. Key changes:

- User: removed streak fields, attempt-related fields and methods from schema and service; removed related controller endpoints. Simplifies user model and avoids daily-streak side-effects.
- Auth: JwtStrategy no longer depends on UserService or attempts to sync daily streaks during validation.
- Challenges: removed normalizedTitle, uniqueness/prevalidate logic and related indexes; simplified create/update flows in challenge services and controllers.
- Judge/Battles: removed many attempt-related audit/logging routines and AI battle submission wiring; removed challenge-attempt controller from module and reduced exported providers.
- AI analysis: simplified complexity fallback handling.
- Analytics: minor cleanup and limit recent submissions returned, plus small formatting tweaks.
- Tooling: adjusted tsconfig types and added tsconfig.spec.json; updated jest-e2e config to point to spec tsconfig.

Overall this refactor removes complex streak/attempt behaviors and duplicate-title heuristics, streamlines services, and reduces side effects during auth and judging flows.