### PR TITLE
Add tsconfig.spec.json for tests

### DIFF
--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["node", "jest"]
+  },
+  "include": ["src/**/*.spec.ts", "src/**/*.test.ts", "test/**/*.ts"]
+}


### PR DESCRIPTION
Introduce a TypeScript config for unit tests that extends the project's tsconfig.json. It adds compiler types for 'node' and 'jest' and includes spec/test files under src and test directories so test files are properly type-checked.