### PR TITLE
Add Upstash support and speed-challenge hint API

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -134,11 +134,11 @@ export class AuthService {
 				if (jsonMatch) {
 					const parsed = JSON.parse(jsonMatch[0]);
 					if (Array.isArray(parsed)) {
-						// Save to cache for 1 day
+						// Save to cache for 3 days
 						try {
 							const promptHash = crypto.createHash('sha256').update(prompt).digest('hex');
 							const cacheKey = `groq:challenges:${promptHash}`;
-							await this.cacheService.set(cacheKey, JSON.stringify(parsed), 60 * 60 * 24);
+							await this.cacheService.set(cacheKey, JSON.stringify(parsed), 60 * 60 * 24 * 3);
 						} catch (e) {
 							console.warn('Failed to cache generated challenges:', (e as Error).message);
 						}

--- a/src/cache/cache.service.ts
+++ b/src/cache/cache.service.ts
@@ -4,10 +4,12 @@ import { createClient } from 'redis';
 @Injectable()
 export class CacheService implements OnModuleInit {
   private client: ReturnType<typeof createClient> | null = null;
+  private upstashUrl: string | null = null;
+  private upstashToken: string | null = null;
   private enabled: boolean;
 
   constructor() {
-    this.enabled = process.env.REDIS_CACHE === 'true';
+    this.enabled = process.env.REDIS_CACHE === 'true' || !!process.env.UPSTASH_REDIS_REST_URL;
   }
 
   async onModuleInit() {
@@ -18,34 +20,70 @@ export class CacheService implements OnModuleInit {
 
   private async initializeClient() {
     try {
+      const upstashUrl = process.env.UPSTASH_REDIS_REST_URL;
+      const upstashToken = process.env.UPSTASH_REDIS_REST_TOKEN;
       const redisUrl = process.env.REDIS_URL;
-      
-      if (!redisUrl) {
-        console.warn('REDIS_URL not set in environment');
-        this.enabled = false;
+
+      if (upstashUrl && upstashToken) {
+        this.upstashUrl = upstashUrl;
+        this.upstashToken = upstashToken;
+        console.log('✓ Redis cache connected (Upstash REST)');
         return;
       }
 
-      this.client = createClient({
-        url: redisUrl,
-      });
+      if (redisUrl) {
+        this.client = createClient({
+          url: redisUrl,
+        });
 
-      this.client.on('error', (err) => {
-        console.warn('Redis cache error:', err.message);
-        this.enabled = false;
-      });
+        this.client.on('error', (err) => {
+          console.warn('Redis cache error:', err.message);
+          this.enabled = false;
+        });
 
-      await this.client.connect();
-      console.log('✓ Redis cache connected (Upstash)');
+        await this.client.connect();
+        console.log('✓ Redis cache connected (Redis client)');
+        return;
+      }
+
+      console.warn('No Redis configuration found (set UPSTASH_REDIS_REST_URL/UPSTASH_REDIS_REST_TOKEN or REDIS_URL)');
+      this.enabled = false;
     } catch (err) {
       console.warn('Redis cache unavailable:', err?.message);
       this.enabled = false;
     }
   }
 
+  private async upstashCommand<T = unknown>(command: unknown[]): Promise<T | null> {
+    if (!this.upstashUrl || !this.upstashToken) return null;
+
+    const response = await fetch(this.upstashUrl, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${this.upstashToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(command),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Upstash cache ${response.status}: ${errorText}`);
+    }
+
+    const payload = await response.json() as { result?: T };
+    return (payload?.result ?? null) as T | null;
+  }
+
   async get(key: string): Promise<string | null> {
-    if (!this.enabled || !this.client) return null;
+    if (!this.enabled) return null;
     try {
+      if (this.upstashUrl && this.upstashToken) {
+        const result = await this.upstashCommand<string>(['GET', key]);
+        return result ?? null;
+      }
+
+      if (!this.client) return null;
       return await this.client.get(key);
     } catch (err) {
       console.warn('Cache get error:', err?.message);
@@ -54,8 +92,17 @@ export class CacheService implements OnModuleInit {
   }
 
   async set(key: string, value: string, ttlSeconds?: number): Promise<void> {
-    if (!this.enabled || !this.client) return;
+    if (!this.enabled) return;
     try {
+      if (this.upstashUrl && this.upstashToken) {
+        const command = ttlSeconds
+          ? ['SET', key, value, 'EX', ttlSeconds]
+          : ['SET', key, value];
+        await this.upstashCommand(command);
+        return;
+      }
+
+      if (!this.client) return;
       if (ttlSeconds) {
         await this.client.setEx(key, ttlSeconds, value);
       } else {
@@ -67,8 +114,14 @@ export class CacheService implements OnModuleInit {
   }
 
   async delete(key: string): Promise<void> {
-    if (!this.enabled || !this.client) return;
+    if (!this.enabled) return;
     try {
+      if (this.upstashUrl && this.upstashToken) {
+        await this.upstashCommand(['DEL', key]);
+        return;
+      }
+
+      if (!this.client) return;
       await this.client.del(key);
     } catch (err) {
       console.warn('Cache delete error:', err?.message);
@@ -76,8 +129,14 @@ export class CacheService implements OnModuleInit {
   }
 
   async exists(key: string): Promise<boolean> {
-    if (!this.enabled || !this.client) return false;
+    if (!this.enabled) return false;
     try {
+      if (this.upstashUrl && this.upstashToken) {
+        const result = await this.upstashCommand<number>(['EXISTS', key]);
+        return result === 1;
+      }
+
+      if (!this.client) return false;
       const result = await this.client.exists(key);
       return result === 1;
     } catch (err) {

--- a/src/onboarding/onboarding.controller.ts
+++ b/src/onboarding/onboarding.controller.ts
@@ -1,7 +1,8 @@
-import { Controller, Get, Post, Body, HttpCode } from '@nestjs/common';
+import { Controller, Get, Post, Body, HttpCode, UseGuards } from '@nestjs/common';
 import { join } from 'path';
 import * as fs from 'fs';
 import { OnboardingService, SolutionInput } from './onboarding.service';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 
 @Controller()
 export class OnboardingController {
@@ -67,5 +68,23 @@ export class OnboardingController {
     const { solutions = [], totalSeconds = 900 } = body;
     const result = await this.onboardingService.classifySolutions(solutions, totalSeconds);
     return result;
+  }
+
+  @Post('speed-challenge/hint')
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(200)
+  async speedChallengeHint(
+    @Body() body: { title: string; description: string; hintLevel?: number },
+  ) {
+    const title = String(body?.title || '').trim();
+    const description = String(body?.description || '').trim();
+    const hintLevel = Number.isFinite(Number(body?.hintLevel)) ? Number(body?.hintLevel) : 1;
+
+    if (!title || !description) {
+      return { hint: 'No problem details available for this hint.' };
+    }
+
+    const hint = await this.onboardingService.generateSpeedChallengeHint(title, description, hintLevel);
+    return { hint };
   }
 }

--- a/src/onboarding/onboarding.module.ts
+++ b/src/onboarding/onboarding.module.ts
@@ -4,9 +4,10 @@ import { OnboardingService } from './onboarding.service';
 import { SettingsModule } from '../settings/settings.module';
 import { AiModule } from '../ai/ai.module';
 import { CacheModule } from '../cache/cache.module';
+import { JudgeModule } from '../judge/judge.module';
 
 @Module({
-  imports: [SettingsModule, AiModule, CacheModule],
+  imports: [SettingsModule, AiModule, CacheModule, JudgeModule],
   controllers: [OnboardingController],
   providers: [OnboardingService],
 })

--- a/src/onboarding/onboarding.service.ts
+++ b/src/onboarding/onboarding.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { SettingsService } from '../settings/settings.service';
 import { CacheService } from '../cache/cache.service';
+import { AIAnalysisService } from '../judge/services/ai-analysis.service';
 import * as crypto from 'crypto';
 
 // ─── DTOs ─────────────────────────────────────────────────────────────────────
@@ -81,10 +82,15 @@ export class OnboardingService {
     private readonly settingsService: SettingsService,
     private readonly configService: ConfigService,
     private readonly cacheService: CacheService,
+    private readonly aiAnalysisService: AIAnalysisService,
   ) {
     if (!this.groqApiKey) {
       this.logger.warn('GROQ_API_KEY not set — AI scoring will be disabled');
     }
+  }
+
+  async generateSpeedChallengeHint(title: string, description: string, hintLevel = 1): Promise<string> {
+    return this.aiAnalysisService.generateHint(title, description, hintLevel);
   }
 
   // ── Public entry point ──────────────────────────────────────────────────────
@@ -330,11 +336,11 @@ END_JSON_RESPONSE`;
     const data = await res.json() as { choices: Array<{ message: { content: string } }> };
     const content = data.choices[0]?.message?.content ?? '';
 
-    // Save to cache (7 days)
+    // Save to cache (3 days)
     try {
       const promptHash = crypto.createHash('sha256').update(prompt).digest('hex');
       const cacheKey = `groq:${promptHash}`;
-      await this.cacheService.set(cacheKey, content, 60 * 60 * 24 * 7);
+      await this.cacheService.set(cacheKey, content, 60 * 60 * 24 * 3);
     } catch (e) {
       this.logger.warn('Groq cache save failed: ' + (e as Error).message);
     }


### PR DESCRIPTION
Introduce Upstash REST support to the cache service and add a protected speed-challenge hint endpoint.

- cache.service.ts: Add UPSTASH_REDIS_REST_URL/UPSTASH_REDIS_REST_TOKEN support, upstashCommand helper, and fallbacks to the redis client; adjust enabled checks and improve connection/error logging. get/set/delete/exists now use Upstash REST when configured.
- auth.service.ts: Increase cached challenge TTL from 1 day to 3 days.
- onboarding.controller.ts: Add a JWT-guarded POST /speed-challenge/hint endpoint to return generated hints.
- onboarding.module.ts / onboarding.service.ts: Wire in JudgeModule and AIAnalysisService, add generateSpeedChallengeHint delegating to the AI analysis service, and shorten Groq cache TTL from 7 days to 3 days.

These changes enable Upstash-based caching, standardize cache TTLs, and add a new authenticated API for hint generation.