### PR TITLE
add battle XP/expiry handling

### DIFF
--- a/nest-cli.json
+++ b/nest-cli.json
@@ -4,9 +4,6 @@
   "sourceRoot": "src",
   "compilerOptions": {
     "deleteOutDir": true,
-    "assets": [
-      { "include": "i18n/**/*", "watchAssets": true }
-    ],
     "plugins": [
       "@nestjs/swagger"
     ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,10 +18,8 @@
         "@nestjs/mongoose": "^11.0.0",
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.0.1",
-        "@nestjs/platform-ws": "^11.1.18",
         "@nestjs/swagger": "^11.2.6",
         "@nestjs/typeorm": "^11.0.0",
-        "@nestjs/websockets": "^11.1.18",
         "@types/nodemailer": "^7.0.11",
         "@types/passport-github2": "^1.2.9",
         "@types/passport-google-oauth20": "^2.0.17",
@@ -34,7 +32,6 @@
         "groq-sdk": "^0.37.0",
         "mongodb": "^6.21.0",
         "mongoose": "^7.6.0",
-        "nestjs-i18n": "^10.6.0",
         "nodemailer": "^8.0.1",
         "openai": "^6.33.0",
         "passport": "^0.6.0",
@@ -47,8 +44,7 @@
         "rxjs": "^7.8.1",
         "swagger-ui-express": "^5.0.1",
         "systeminformation": "^5.31.1",
-        "typeorm": "^0.3.28",
-        "ws": "^8.20.0"
+        "typeorm": "^0.3.28"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",
@@ -2907,25 +2903,6 @@
         "@nestjs/core": "^11.0.0"
       }
     },
-    "node_modules/@nestjs/platform-ws": {
-      "version": "11.1.18",
-      "resolved": "https://registry.npmjs.org/@nestjs/platform-ws/-/platform-ws-11.1.18.tgz",
-      "integrity": "sha512-+MWW1R6PJIc3zFEePH19lQ8j5jjUbVR1jhFNSQOvV4yHI737sPEQtGbuFri/C/Axeu29EBA4E3TRN5tsOw7jXg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "2.8.1",
-        "ws": "8.20.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/nest"
-      },
-      "peerDependencies": {
-        "@nestjs/common": "^11.0.0",
-        "@nestjs/websockets": "^11.0.0",
-        "rxjs": "^7.1.0"
-      }
-    },
     "node_modules/@nestjs/schematics": {
       "version": "11.0.9",
       "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-11.0.9.tgz",
@@ -3120,29 +3097,6 @@
         "reflect-metadata": "^0.1.13 || ^0.2.0",
         "rxjs": "^7.2.0",
         "typeorm": "^0.3.0"
-      }
-    },
-    "node_modules/@nestjs/websockets": {
-      "version": "11.1.18",
-      "resolved": "https://registry.npmjs.org/@nestjs/websockets/-/websockets-11.1.18.tgz",
-      "integrity": "sha512-HLO/QGlJoJaMMDphgjbcIwW7/8EA8nnFQjf+qPvA+wWLLfPKoiFPUezc5m9YgN2A7jmzwo6YmEAXeHyqO9tvTw==",
-      "license": "MIT",
-      "dependencies": {
-        "iterare": "1.2.1",
-        "object-hash": "3.0.0",
-        "tslib": "2.8.1"
-      },
-      "peerDependencies": {
-        "@nestjs/common": "^11.0.0",
-        "@nestjs/core": "^11.0.0",
-        "@nestjs/platform-socket.io": "^11.0.0",
-        "reflect-metadata": "^0.1.12 || ^0.2.0",
-        "rxjs": "^7.1.0"
-      },
-      "peerDependenciesMeta": {
-        "@nestjs/platform-socket.io": {
-          "optional": true
-        }
       }
     },
     "node_modules/@noble/hashes": {
@@ -4933,12 +4887,6 @@
         "node": ">=6.5"
       }
     },
-    "node_modules/accept-language-parser": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/accept-language-parser/-/accept-language-parser-1.5.0.tgz",
-      "integrity": "sha512-QhyTbMLYo0BBGg1aWbeMG4ekWtds/31BrEU+DONOg/7ax23vxpL03Pb7/zBmha2v7vdD3AyzZVWBVGEZxKOXWw==",
-      "license": "MIT"
-    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -5145,6 +5093,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -5158,6 +5107,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -5506,18 +5456,6 @@
         "node": "*"
       }
     },
-    "node_modules/binary-extensions": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
-      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -5576,6 +5514,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -7365,6 +7304,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -7599,6 +7539,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -8083,18 +8024,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/is-binary-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "license": "MIT",
-      "dependencies": {
-        "binary-extensions": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -8111,6 +8040,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8139,6 +8069,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -8161,6 +8092,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -10034,89 +9966,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/nestjs-i18n": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/nestjs-i18n/-/nestjs-i18n-10.6.0.tgz",
-      "integrity": "sha512-fPOgwrnb8u8UO6YXNlnamF7GDhNLOHQE8hD/pT/L7oUQibvL7PBZYZgquwppOFRaOPnH0uING2BzQGq7uQNNmQ==",
-      "license": "MIT",
-      "dependencies": {
-        "accept-language-parser": "^1.5.0",
-        "chokidar": "^3.6.0",
-        "cookie": "^0.7.0",
-        "iterare": "^1.2.1",
-        "js-yaml": "^4.1.0",
-        "string-format": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@nestjs/common": "*",
-        "@nestjs/core": "*",
-        "class-validator": "*",
-        "rxjs": "*"
-      }
-    },
-    "node_modules/nestjs-i18n/node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "license": "MIT",
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/nestjs-i18n/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/nestjs-i18n/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/nestjs-i18n/node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "license": "MIT",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      }
-    },
     "node_modules/node-abort-controller": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
@@ -10223,6 +10072,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10254,15 +10104,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-hash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
-      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/object-inspect": {
@@ -11662,12 +11503,6 @@
         "safe-buffer": "~5.2.0"
       }
     },
-    "node_modules/string-format": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/string-format/-/string-format-2.0.0.tgz",
-      "integrity": "sha512-bbEs3scLeYNXLecRRuk6uJxdXUSj6le/8rNPHChIJTn2V79aXVTR1EH2OH5zLKKoz0V02fOUKZZcw01pLUShZA==",
-      "license": "WTFPL OR MIT"
-    },
     "node_modules/string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -12133,6 +11968,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -13300,27 +13136,6 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/xmlchars": {

--- a/package.json
+++ b/package.json
@@ -29,10 +29,8 @@
     "@nestjs/mongoose": "^11.0.0",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
-    "@nestjs/platform-ws": "^11.1.18",
     "@nestjs/swagger": "^11.2.6",
     "@nestjs/typeorm": "^11.0.0",
-    "@nestjs/websockets": "^11.1.18",
     "@types/nodemailer": "^7.0.11",
     "@types/passport-github2": "^1.2.9",
     "@types/passport-google-oauth20": "^2.0.17",
@@ -45,7 +43,6 @@
     "groq-sdk": "^0.37.0",
     "mongodb": "^6.21.0",
     "mongoose": "^7.6.0",
-    "nestjs-i18n": "^10.6.0",
     "nodemailer": "^8.0.1",
     "openai": "^6.33.0",
     "passport": "^0.6.0",
@@ -58,8 +55,7 @@
     "rxjs": "^7.8.1",
     "swagger-ui-express": "^5.0.1",
     "systeminformation": "^5.31.1",
-    "typeorm": "^0.3.28",
-    "ws": "^8.20.0"
+    "typeorm": "^0.3.28"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,9 +1,6 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { APP_GUARD } from '@nestjs/core';
-import * as path from 'path';
-import { I18nModule, AcceptLanguageResolver } from 'nestjs-i18n';
-import { I18nJsonLoader } from 'nestjs-i18n/dist/loaders';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { OnboardingModule } from './onboarding/onboarding.module';
@@ -22,22 +19,11 @@ import { ChallengesModule } from './challenges/challenges.module';
 import { CacheModule } from './cache/cache.module';
 import { BattlesModule } from './battles/battle.module';
 import { JudgeModule } from './judge/judge.module';
-import { ChatModule } from './chat/chat.module';
-import { SupportModule } from './support/support.module';
 
 @Module({
   imports: [
     ConfigModule.forRoot({
       isGlobal: true,
-    }),
-    I18nModule.forRoot({
-      fallbackLanguage: 'en',
-      loader: I18nJsonLoader,
-      loaderOptions: {
-        path: path.join(__dirname, 'i18n'),
-        watch: process.env.NODE_ENV !== 'production',
-      },
-      resolvers: [AcceptLanguageResolver],
     }),
     MongooseModule.forRoot(process.env.MONGO_URI || 'mongodb://localhost:27017/algoarena'),
     UserModule,
@@ -54,8 +40,6 @@ import { SupportModule } from './support/support.module';
     AiModule,
     ChallengeModule,
     JudgeModule,
-    ChatModule,
-    SupportModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -7,7 +7,6 @@ import { CreateUserDto } from '../user/dto/create-user.dto';
 import type { Response } from 'express';
 import type { Request } from 'express';
 import { UserService } from '../user/user.service';
-import { I18nContext, I18nService } from 'nestjs-i18n';
 
 class LoginDto {
 	@IsString()
@@ -26,13 +25,7 @@ export class AuthController {
 	constructor(
 		private readonly authService: AuthService,
 		private readonly users: UserService,
-		private readonly i18n: I18nService,
-	) {}
-
-	private tr(key: string, args?: Record<string, unknown>): string {
-		const lang = I18nContext.current()?.lang ?? 'en';
-		return this.i18n.translate(key, { lang, args }) as string;
-	}
+	) { }
 
 	        @ApiOperation({
         summary: 'Post_register_1 operation',
@@ -67,10 +60,10 @@ Content-Type: application/json
 	@Post('register')
         async register(@Body() dto: CreateUserDto, @Res({ passthrough: true }) res: Response) {
 		const existingUsername = await this.users.findByUsername(dto.username);
-		if (existingUsername) throw new BadRequestException(this.tr('auth.usernameTaken'));
+		if (existingUsername) throw new BadRequestException('Username is already taken');
 
 		const existingEmail = await this.users.findByEmail(dto.email);
-		if (existingEmail) throw new BadRequestException(this.tr('auth.emailTaken'));
+		if (existingEmail) throw new BadRequestException('Email is already taken');
 		this.authService.ensurePasswordIsSafe(dto.password, dto.username, dto.email);
 
                 const created = await this.authService.register(dto);
@@ -125,7 +118,7 @@ Content-Type: application/json
 	async checkAvailability(@Body() body: { username?: string; email?: string }) {
 		if (body.username) {
 			const existingUsername = await this.users.findByUsername(body.username);
-			if (existingUsername) return { available: false, message: this.tr('auth.usernameTaken') };
+			if (existingUsername) return { available: false, message: 'Username is already taken' };
 			return { available: true };
 		}
 		if (body.email) {
@@ -135,10 +128,10 @@ Content-Type: application/json
 			}
 
 			const existingEmail = await this.users.findByEmail(body.email);
-			if (existingEmail) return { available: false, message: this.tr('auth.emailTaken') };
+			if (existingEmail) return { available: false, message: 'Email is already taken' };
 			return { available: true, suspicious: validation.suspicious };
 		}
-		throw new BadRequestException(this.tr('auth.mustProvideUsernameOrEmail'));
+		throw new BadRequestException('Must provide username or email');
 	}
 
 	        @ApiOperation({
@@ -173,9 +166,9 @@ Content-Type: application/json
     @ApiResponse({ status: 403, description: 'Forbidden - Insufficient permissions' })
     @Post('login')
 	async login(@Body() body: LoginDto, @Res({ passthrough: true }) res: Response) {
-		if (!body || !body.username || !body.password) throw new BadRequestException(this.tr('auth.usernamePasswordRequired'));
+		if (!body || !body.username || !body.password) throw new BadRequestException('username and password are required');
 		const user = await this.authService.validateUser(body.username, body.password, body.recaptchaToken);
-		if (!user) throw new UnauthorizedException(this.tr('auth.invalidCredentials'));
+		if (!user) throw new UnauthorizedException('Invalid credentials');
 		const tokens = await this.authService.login(user);
 		res.cookie('refresh_token', tokens.refresh_token, {
 			path: '/',
@@ -371,7 +364,7 @@ Content-Type: application/json
 	@HttpCode(200)
 	async refresh(@Req() req: Request, @Res() res: Response) {
 		const refreshToken = req.cookies?.refresh_token;
-		if (!refreshToken) throw new UnauthorizedException(this.tr('auth.noRefreshToken'));
+		if (!refreshToken) throw new UnauthorizedException('No refresh token');
 		const tokens = await this.authService.refreshTokens(refreshToken);
 		res.cookie('refresh_token', tokens.refresh_token, {
 			httpOnly: true,
@@ -454,7 +447,7 @@ Content-Type: application/json
     @ApiResponse({ status: 403, description: 'Forbidden - Insufficient permissions' })
     @Post('forgot-password')
 	async forgotPassword(@Body() body: { email: string }) {
-		if (!body.email) throw new BadRequestException(this.tr('auth.emailRequired'));
+		if (!body.email) throw new BadRequestException('email is required');
 		return this.authService.requestPasswordReset(body.email);
 	}
 
@@ -490,7 +483,7 @@ Content-Type: application/json
     @ApiResponse({ status: 403, description: 'Forbidden - Insufficient permissions' })
     @Post('verify-reset-code')
 	async verifyResetCode(@Body() body: { email: string; code: string }) {
-		if (!body.email || !body.code) throw new BadRequestException(this.tr('auth.missingEmailOrCode'));
+		if (!body.email || !body.code) throw new BadRequestException('Missing email or code');
 		return this.authService.verifyResetPasswordCode(body.email, body.code);
 	}
 
@@ -527,7 +520,7 @@ Content-Type: application/json
     @Post('reset-password')
 	async resetPassword(@Body() body: any) {
 		if (!body.token || !body.newPassword || !body.confirmPassword) {
-			throw new BadRequestException(this.tr('auth.missingRequiredFields'));
+			throw new BadRequestException('Missing required fields');
 		}
 		return this.authService.resetPassword(body.token, body.newPassword, body.confirmPassword);
 	}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -7,8 +7,10 @@ import { EmailService } from './email.service';
 import { SettingsService } from '../settings/settings.service';
 import { CacheService } from '../cache/cache.service';
 import { EmailDeliverabilityService, EmailValidationResult } from './email-deliverability.service';
-import { passwordContainsIdentityData } from './password-policy.util';
-import { I18nContext, I18nService } from 'nestjs-i18n';
+import {
+	PASSWORD_SECURITY_MESSAGE,
+	passwordContainsIdentityData,
+} from './password-policy.util';
 import * as crypto from 'crypto';
 import * as fs from 'fs';
 import { join } from 'path';
@@ -27,20 +29,14 @@ export class AuthService {
 		private readonly configService: ConfigService,
 		private readonly cacheService: CacheService,
 		private readonly emailDeliverabilityService: EmailDeliverabilityService,
-		private readonly i18n: I18nService,
-	) {}
-
-	private tr(key: string, args?: Record<string, unknown>): string {
-		const lang = I18nContext.current()?.lang ?? 'en';
-		return this.i18n.translate(key, { lang, args }) as string;
-	}
+	) { }
 
 	async register(dto: any) {
 		const settings: any = await this.settingsService.getSettings();
 		if (settings && !settings.userRegistration) {
-			throw new BadRequestException(this.tr('auth.registrationDisabled'));
+			throw new BadRequestException('Registration is disabled');
 		}
-		if (!dto.recaptchaToken) throw new UnauthorizedException(this.tr('auth.recaptchaRequired'));
+		if (!dto.recaptchaToken) throw new UnauthorizedException('reCAPTCHA token is required');
 		await this.recaptchaService.validate(dto.recaptchaToken);
 		this.ensurePasswordIsSafe(dto.password, dto.username, dto.email);
 		const emailValidation = await this.validateDeliverableEmail(dto.email);
@@ -70,7 +66,7 @@ export class AuthService {
 
 	ensurePasswordIsSafe(password: string, username: string, email: string) {
 		if (passwordContainsIdentityData(password, username, email)) {
-			throw new BadRequestException(this.tr('auth.passwordContainsIdentity'));
+			throw new BadRequestException(PASSWORD_SECURITY_MESSAGE);
 		}
 	}
 
@@ -172,7 +168,7 @@ export class AuthService {
 	}
 
 	async validateUser(username: string, password: string, recaptchaToken?: string) {
-		if (!recaptchaToken) throw new UnauthorizedException(this.tr('auth.recaptchaRequired'));
+		if (!recaptchaToken) throw new UnauthorizedException('reCAPTCHA token is required');
 		await this.recaptchaService.validate(recaptchaToken);
 		if (!password) return null;
 		const crypto = require('crypto');
@@ -266,7 +262,7 @@ export class AuthService {
 
 			return { access_token: accessToken, refresh_token: newRefreshToken };
 		} catch (e) {
-			throw new UnauthorizedException(this.tr('auth.invalidRefreshToken'));
+			throw new UnauthorizedException('Invalid refresh token');
 		}
 	}
 
@@ -284,7 +280,7 @@ export class AuthService {
 
 	async requestPasswordReset(email: string) {
 		const user = await this.users.findByEmail(email);
-		if (!user) return { message: this.tr('auth.resetIfExists') };
+		if (!user) return { message: 'If email exists, a reset link was sent' };
 
 		const plainToken = crypto.randomBytes(32).toString('hex');
 		const tokenHash = crypto.createHash('sha256').update(plainToken).digest('hex');
@@ -294,7 +290,7 @@ export class AuthService {
 		await this.users.setResetPasswordToken(email, tokenHash, expires, confirmationCode);
 		await this.emailService.sendPasswordResetEmail(email, plainToken, confirmationCode);
 
-		return { message: this.tr('auth.resetEmailSent') };
+		return { message: 'Reset email sent' };
 	}
 
 	/**
@@ -302,19 +298,19 @@ export class AuthService {
 	 */
 	async verifyResetPasswordCode(email: string, code: string) {
 		const user = await this.users.verifyResetPasswordCode(email, code);
-		if (!user) throw new BadRequestException(this.tr('auth.invalidConfirmationCode'));
-		return { message: this.tr('auth.codeVerified') };
+		if (!user) throw new BadRequestException('Invalid or expired confirmation code');
+		return { message: 'Code verified. You may now reset your password.' };
 	}
 
 	async resetPassword(token: string, newPassword: string, confirmPassword: string) {
-		if (newPassword !== confirmPassword) throw new BadRequestException(this.tr('auth.passwordsDoNotMatch'));
+		if (newPassword !== confirmPassword) throw new BadRequestException('Passwords do not match');
 
 		const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
 		const user = await this.users.findByResetPasswordToken(tokenHash);
 
-		if (!user) throw new BadRequestException(this.tr('auth.invalidOrExpiredToken'));
+		if (!user) throw new BadRequestException('Invalid or expired token');
 		if (!user.resetPasswordCodeVerified) {
-			throw new BadRequestException(this.tr('auth.confirmationNotVerified'));
+			throw new BadRequestException('Confirmation code not verified');
 		}
 
 		const passwordHash = crypto.createHash('sha256').update(newPassword).digest('hex');
@@ -322,6 +318,6 @@ export class AuthService {
 		const rawId = (user as any)._id || (user as any).userId || (user as any).id;
 		await this.users.updatePasswordAndClearToken(rawId.toString(), passwordHash);
 
-		return { message: this.tr('auth.passwordUpdated') };
+		return { message: 'Password updated successfully' };
 	}
 }

--- a/src/auth/email-deliverability.service.ts
+++ b/src/auth/email-deliverability.service.ts
@@ -1,5 +1,4 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { I18nContext, I18nService } from 'nestjs-i18n';
 import { promises as dns } from 'dns';
 import disposableDomainsList from 'disposable-email-domains';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -24,8 +23,6 @@ export interface EmailValidationResult {
 @Injectable()
 export class EmailDeliverabilityService {
   private readonly logger = new Logger(EmailDeliverabilityService.name);
-
-  constructor(private readonly i18n: I18nService) {}
   private readonly domainCache = new Map<string, CacheValue>();
   private readonly cacheTtlMs = 10 * 60 * 1000;
   private readonly mxTimeoutMs = 2500;
@@ -101,12 +98,18 @@ export class EmailDeliverabilityService {
   }
 
   private result(valid: boolean, reason: EmailValidationReason, suspicious: boolean): EmailValidationResult {
-    const lang = I18nContext.current()?.lang ?? 'en';
-    const message = this.i18n.translate(`emailValidation.${reason}`, { lang }) as string;
+    const reasonMessages: Record<EmailValidationReason, string> = {
+      ok: 'Email is valid',
+      invalid_format: 'Invalid email format',
+      fake_pattern: 'Invalid email format',
+      disposable: 'Disposable emails are not allowed',
+      no_mx: 'Email domain cannot receive emails',
+    };
+
     return {
       valid,
       reason,
-      message,
+      message: reasonMessages[reason],
       suspicious,
     };
   }

--- a/src/auth/recaptcha.service.ts
+++ b/src/auth/recaptcha.service.ts
@@ -1,22 +1,14 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
-import { I18nContext, I18nService } from 'nestjs-i18n';
 
 @Injectable()
 export class RecaptchaService {
-    constructor(private readonly i18n: I18nService) {}
-
-    private tr(key: string): string {
-        const lang = I18nContext.current()?.lang ?? 'en';
-        return this.i18n.translate(key, { lang }) as string;
-    }
-
     async validate(token: string): Promise<boolean> {
         if (!token) {
-            throw new UnauthorizedException(this.tr('recaptcha.tokenMissing'));
+            throw new UnauthorizedException('reCAPTCHA token is missing');
         }
 
         const secret = process.env.RECAPTCHA_SECRET;
-        if (!secret) throw new UnauthorizedException(this.tr('recaptcha.secretNotConfigured'));
+        if (!secret) throw new UnauthorizedException('reCAPTCHA secret key not configured');
         const response = await fetch('https://www.google.com/recaptcha/api/siteverify', {
             method: 'POST',
             headers: {
@@ -28,10 +20,10 @@ export class RecaptchaService {
         const data = await response.json();
         // Pour reCAPTCHA v3 : vérifier le score et l'action
         if (!data.success) {
-            throw new UnauthorizedException(this.tr('recaptcha.validationFailed'));
+            throw new UnauthorizedException('reCAPTCHA validation failed');
         }
         if (data.score !== undefined && data.score < 0.5) {
-            throw new UnauthorizedException(this.tr('recaptcha.scoreTooLow'));
+            throw new UnauthorizedException('reCAPTCHA score too low');
         }
         // Optionnel : vérifier l'action si vous l'utilisez côté frontend
         // if (data.action !== 'signup') {

--- a/src/auth/speed-challenge.guard.ts
+++ b/src/auth/speed-challenge.guard.ts
@@ -1,31 +1,22 @@
 import { Injectable, CanActivate, ExecutionContext, UnauthorizedException, ForbiddenException } from '@nestjs/common';
-import { I18nContext, I18nService } from 'nestjs-i18n';
 import { UserService } from '../user/user.service';
 
 @Injectable()
 export class SpeedChallengeGuard implements CanActivate {
-  constructor(
-    private readonly users: UserService,
-    private readonly i18n: I18nService,
-  ) {}
-
-  private tr(key: string): string {
-    const lang = I18nContext.current()?.lang ?? 'en';
-    return this.i18n.translate(key, { lang }) as string;
-  }
+  constructor(private readonly users: UserService) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const req = context.switchToHttp().getRequest();
     const user = req.user;
-    if (!user) throw new UnauthorizedException(this.tr('speedChallengeGuard.authRequired'));
+    if (!user) throw new UnauthorizedException('Authentication required');
 
     // Support different JWT payload shapes: { userId } or { sub }
     const userId = user.userId || user.sub || user.id || user._id;
-    if (!userId) throw new UnauthorizedException(this.tr('speedChallengeGuard.invalidTokenPayload'));
+    if (!userId) throw new UnauthorizedException('Invalid token payload');
 
     const completed = await this.users.hasCompletedSpeedChallenge(String(userId));
     if (completed) return true;
 
-    throw new ForbiddenException(this.tr('speedChallengeGuard.mustComplete'));
+    throw new ForbiddenException('Speed challenge must be completed');
   }
 }

--- a/src/battles/battle-ai.service.ts
+++ b/src/battles/battle-ai.service.ts
@@ -1,5 +1,4 @@
 import { Injectable, Logger, BadRequestException, HttpException, HttpStatus } from '@nestjs/common';
-import { I18nContext, I18nService } from 'nestjs-i18n';
 import { ConfigService } from '@nestjs/config';
 import { BattlesService } from './battle.service';
 import { ChallengeService } from '../challenges/challenge.service';
@@ -38,7 +37,6 @@ export class BattleAiService {
     private readonly challengeService: ChallengeService,
     private readonly dockerService: DockerExecutionService,
     private readonly analysisService: AIAnalysisService,
-    private readonly i18n: I18nService,
   ) {
     const grokKey = this.config.get<string>('GROK_API_KEY');
     const groqKey = this.config.get<string>('GROQ_API_KEY');
@@ -61,25 +59,20 @@ export class BattleAiService {
     }
   }
 
-  private tr(key: string, args?: Record<string, unknown>): string {
-    const lang = I18nContext.current()?.lang ?? 'en';
-    return this.i18n.translate(key, { lang, args }) as string;
-  }
-
   async submitAiSolution(battleId: string, language: 'javascript' | 'python' = 'javascript'): Promise<AiSubmissionResult> {
     if (!battleId) {
-      throw new BadRequestException(this.tr('battleAi.battleIdRequired'));
+      throw new BadRequestException('battleId is required');
     }
 
     try {
       const battle = await this.battlesService.findOne(battleId);
       if (!battle?.challengeId) {
-        throw new BadRequestException(this.tr('battleAi.missingChallengeId'));
+        throw new BadRequestException('Battle is missing a challengeId');
       }
 
       const challenge = await this.challengeService.findById(battle.challengeId);
       if (!challenge) {
-        throw new BadRequestException(this.tr('battleAi.challengeNotFound'));
+        throw new BadRequestException('Challenge not found');
       }
 
       const testCases = (challenge.testCases || []).map((tc) => ({
@@ -88,7 +81,7 @@ export class BattleAiService {
       }));
 
       if (!testCases.length) {
-        throw new BadRequestException(this.tr('battleAi.noTestCases'));
+        throw new BadRequestException('Challenge has no test cases');
       }
 
       const botDifficulty = (battle as any)?.botDifficulty as BotDifficulty | undefined;

--- a/src/battles/battle.module.ts
+++ b/src/battles/battle.module.ts
@@ -7,6 +7,7 @@ import { Battle, BattleSchema } from './schemas/battle.schema';
 import { BattleHistory, BattleHistorySchema } from './schemas/battle-history.schema';
 import { ChallengeModule } from '../challenges/challenge.module';
 import { JudgeModule } from '../judge/judge.module';
+import { UserModule } from '../user/user.module';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { JudgeModule } from '../judge/judge.module';
     ]),
     ChallengeModule,
     JudgeModule,
+    UserModule,
   ],
   controllers: [BattlesController],
   providers: [BattlesService, BattleAiService],

--- a/src/battles/battle.service.ts
+++ b/src/battles/battle.service.ts
@@ -1,22 +1,58 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { I18nContext, I18nService } from 'nestjs-i18n';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { CreateBattleDto } from './dto/create-battle.dto';
 import { UpdateBattleDto } from './dto/update-battle.dto';
 import { Battle, BattleDocument } from './schemas/battle.schema';
 import { BattleStatus } from './battle.enums';
+import { UserService } from '../user/user.service';
 
 @Injectable()
 export class BattlesService {
   constructor(
     @InjectModel(Battle.name) private readonly model: Model<BattleDocument>,
-    private readonly i18n: I18nService,
+    private readonly userService: UserService,
   ) {}
 
-  private tr(key: string, args?: Record<string, unknown>): string {
-    const lang = I18nContext.current()?.lang ?? 'en';
-    return this.i18n.translate(key, { lang, args }) as string;
+  private computeBattleXp(battle: Pick<Battle, 'playerScoreTotal' | 'opponentScoreTotal'>): number {
+    const playerScore = Math.max(0, Number(battle.playerScoreTotal || 0));
+    const opponentScore = Math.max(0, Number(battle.opponentScoreTotal || 0));
+    const winBonus = playerScore > opponentScore ? 250 : 0;
+    return Math.max(0, Math.round(playerScore + winBonus));
+  }
+
+  private isExpired(battle: Pick<Battle, 'startedAt' | 'timeLimitSeconds'>): boolean {
+    const startedAtMs = new Date(battle.startedAt as any).getTime();
+    if (!Number.isFinite(startedAtMs) || startedAtMs <= 0) return false;
+    const limitSeconds = Math.max(1, Number((battle as any).timeLimitSeconds || 900));
+    const deadlineMs = startedAtMs + limitSeconds * 1000;
+    return Date.now() >= deadlineMs;
+  }
+
+  private async maybeFinalizeAndAward(battle: BattleDocument): Promise<BattleDocument> {
+    if (!battle) return battle;
+
+    const shouldFinalize = battle.battleStatus === BattleStatus.ACTIVE && this.isExpired(battle as any);
+    if (shouldFinalize) {
+      battle.battleStatus = BattleStatus.FINISHED;
+      battle.endedAt = battle.endedAt || new Date();
+    }
+
+    const shouldAward = battle.battleStatus === BattleStatus.FINISHED && !Boolean((battle as any).xpAwarded);
+    if (shouldAward) {
+      const xpGranted = this.computeBattleXp(battle as any);
+      if (xpGranted > 0) {
+        await this.userService.updateXpAndRank(battle.userId, xpGranted);
+      }
+      (battle as any).xpGranted = xpGranted;
+      (battle as any).xpAwarded = true;
+    }
+
+    if (shouldFinalize || shouldAward) {
+      await battle.save();
+    }
+
+    return battle;
   }
 
   private async generateIdBattle(): Promise<string> {
@@ -45,22 +81,24 @@ export class BattlesService {
   }
 
   async findAll(): Promise<Battle[]> {
-    return this.model.find().exec();
+    const battles = await this.model.find().exec();
+    return Promise.all(battles.map((b) => this.maybeFinalizeAndAward(b)));
   }
 
   async findByUserId(userId: string): Promise<Battle[]> {
-    return this.model.find({ userId }).exec();
+    const battles = await this.model.find({ userId }).exec();
+    return Promise.all(battles.map((b) => this.maybeFinalizeAndAward(b)));
   }
 
   async findOne(id: string): Promise<Battle> {
     const found = await this.model.findById(id).exec();
-    if (!found) throw new NotFoundException(this.tr('battles.notFoundById', { id }));
-    return found;
+    if (!found) throw new NotFoundException(`Battle with id ${id} not found`);
+    return this.maybeFinalizeAndAward(found);
   }
 
   async update(id: string, dto: UpdateBattleDto): Promise<Battle> {
     const existing = await this.model.findById(id).exec();
-    if (!existing) throw new NotFoundException(this.tr('battles.notFoundById', { id }));
+    if (!existing) throw new NotFoundException(`Battle with id ${id} not found`);
 
     const nextStatus = dto.battleStatus || existing.battleStatus;
     const updatePayload: any = { ...dto };
@@ -70,12 +108,12 @@ export class BattlesService {
     }
 
     const updated = await this.model.findByIdAndUpdate(id, updatePayload, { new: true }).exec();
-    if (!updated) throw new NotFoundException(this.tr('battles.notFoundById', { id }));
-    return updated;
+    if (!updated) throw new NotFoundException(`Battle with id ${id} not found`);
+    return this.maybeFinalizeAndAward(updated);
   }
 
   async remove(id: string): Promise<void> {
     const deleted = await this.model.findByIdAndDelete(id).exec();
-    if (!deleted) throw new NotFoundException(this.tr('battles.notFoundById', { id }));
+    if (!deleted) throw new NotFoundException(`Battle with id ${id} not found`);
   }
 }

--- a/src/battles/dto/create-battle.dto.ts
+++ b/src/battles/dto/create-battle.dto.ts
@@ -38,6 +38,25 @@ export class CreateBattleDto {
   @IsOptional()
   startedAt?: string;
 
+  @IsNumber()
+  @IsOptional()
+  timeLimitSeconds?: number;
+
+  @IsNumber()
+  @IsOptional()
+  playerScoreTotal?: number;
+
+  @IsNumber()
+  @IsOptional()
+  opponentScoreTotal?: number;
+
+  @IsNumber()
+  @IsOptional()
+  xpGranted?: number;
+
+  @IsOptional()
+  xpAwarded?: boolean;
+
   @IsDateString()
   @IsOptional()
   endedAt?: string;

--- a/src/battles/schemas/battle.schema.ts
+++ b/src/battles/schemas/battle.schema.ts
@@ -36,6 +36,21 @@ export class Battle {
   @Prop({ type: Date, default: Date.now })
   startedAt: Date;
 
+  @Prop({ type: Number, default: 900 })
+  timeLimitSeconds: number;
+
+  @Prop({ type: Number, default: 0 })
+  playerScoreTotal: number;
+
+  @Prop({ type: Number, default: 0 })
+  opponentScoreTotal: number;
+
+  @Prop({ type: Boolean, default: false })
+  xpAwarded: boolean;
+
+  @Prop({ type: Number, default: 0 })
+  xpGranted: number;
+
   @Prop({ type: Date })
   endedAt: Date;
 

--- a/src/challenges/challenge.service.ts
+++ b/src/challenges/challenge.service.ts
@@ -1,5 +1,4 @@
 import { Injectable, NotFoundException, ConflictException } from '@nestjs/common';
-import { I18nContext, I18nService } from 'nestjs-i18n';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { Challenge, ChallengeDocument } from './schemas/challenge.schema';
@@ -11,13 +10,7 @@ export class ChallengeService {
     constructor(
         @InjectModel(Challenge.name) private readonly challengeModel: Model<ChallengeDocument>,
         private readonly auditLogService: AuditLogService,
-        private readonly i18n: I18nService,
-    ) {}
-
-    private tr(key: string, args?: Record<string, unknown>): string {
-        const lang = I18nContext.current()?.lang ?? 'en';
-        return this.i18n.translate(key, { lang, args }) as string;
-    }
+    ) { }
 
     private normalizeTitle(title: string): string {
         return (title || '')
@@ -43,12 +36,12 @@ export class ChallengeService {
 
         const exactTitleMatch = await this.challengeModel.findOne({ title }).lean().exec();
         if (exactTitleMatch && String((exactTitleMatch as any)._id) !== String(ignoreId || '')) {
-            throw new ConflictException(this.tr('challenges.titleExists', { title }));
+            throw new ConflictException(`A challenge with the title '${title}' already exists. Please use a unique title.`);
         }
 
         const normalizedTitleMatch = await this.challengeModel.findOne({ normalizedTitle }).lean().exec();
         if (normalizedTitleMatch && String((normalizedTitleMatch as any)._id) !== String(ignoreId || '')) {
-            throw new ConflictException(this.tr('challenges.titleExists', { title }));
+            throw new ConflictException(`A challenge with the title '${title}' already exists. Please use a unique title.`);
         }
 
         const descriptionPrefix = this.normalizeDescriptionPrefix(dto.description || '');
@@ -59,7 +52,7 @@ export class ChallengeService {
                 return this.normalizeDescriptionPrefix(doc?.description || '') === descriptionPrefix;
             });
             if (similar) {
-                warnings.push(this.tr('challenges.duplicateDescriptionWarning', { title: String(similar.title) }));
+                warnings.push(`Potential duplicate description detected with "${similar.title}".`);
             }
         }
 
@@ -176,13 +169,13 @@ export class ChallengeService {
 
     async findById(id: string): Promise<ChallengeDocument> {
         const challenge = await this.challengeModel.findById(id).lean().exec();
-        if (!challenge) throw new NotFoundException(this.tr('challenges.notFound'));
+        if (!challenge) throw new NotFoundException('Challenge not found');
         return challenge as ChallengeDocument;
     }
 
     async update(id: string, dto: Partial<CreateChallengeDto>, actorId?: string, actorName?: string): Promise<ChallengeDocument> {
         const existing = await this.challengeModel.findById(id).lean().exec();
-        if (!existing) throw new NotFoundException(this.tr('challenges.notFound'));
+        if (!existing) throw new NotFoundException('Challenge not found');
         if (dto.title || dto.description) {
             await this.validateDuplicateChallenge(
                 {
@@ -206,7 +199,7 @@ export class ChallengeService {
             )
             .lean()
             .exec();
-        if (!updated) throw new NotFoundException(this.tr('challenges.notFound'));
+        if (!updated) throw new NotFoundException('Challenge not found');
 
         // Build state diff for audit
         const changedFields: Record<string, any> = {};
@@ -238,7 +231,7 @@ export class ChallengeService {
 
     async publish(id: string, actorId?: string, actorName?: string): Promise<ChallengeDocument> {
         const existing = await this.challengeModel.findById(id).lean().exec();
-        if (!existing) throw new NotFoundException(this.tr('challenges.notFound'));
+        if (!existing) throw new NotFoundException('Challenge not found');
 
         const updated = await this.challengeModel
             .findByIdAndUpdate(id, { status: 'published' }, { new: true })
@@ -263,7 +256,7 @@ export class ChallengeService {
 
     async unpublish(id: string, actorId?: string, actorName?: string): Promise<ChallengeDocument> {
         const existing = await this.challengeModel.findById(id).lean().exec();
-        if (!existing) throw new NotFoundException(this.tr('challenges.notFound'));
+        if (!existing) throw new NotFoundException('Challenge not found');
 
         const updated = await this.challengeModel
             .findByIdAndUpdate(id, { status: 'draft' }, { new: true })
@@ -288,7 +281,7 @@ export class ChallengeService {
 
     async remove(id: string, actorId?: string, actorName?: string): Promise<{ deleted: boolean }> {
         const existing = await this.challengeModel.findById(id).lean().exec();
-        if (!existing) throw new NotFoundException(this.tr('challenges.notFound'));
+        if (!existing) throw new NotFoundException('Challenge not found');
 
         await this.challengeModel.findByIdAndDelete(id).exec();
 

--- a/src/challenges/challenges.service.ts
+++ b/src/challenges/challenges.service.ts
@@ -1,5 +1,4 @@
 import { Injectable, NotFoundException, ConflictException } from '@nestjs/common';
-import { I18nContext, I18nService } from 'nestjs-i18n';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { CreateChallengeDto } from './dto/create-challenge.dto';
@@ -10,13 +9,7 @@ import { Challenge, ChallengeDocument } from './schemas/challenge.schema';
 export class ChallengesService {
   constructor(
     @InjectModel(Challenge.name) private readonly model: Model<ChallengeDocument>,
-    private readonly i18n: I18nService,
   ) {}
-
-  private tr(key: string, args?: Record<string, unknown>): string {
-    const lang = I18nContext.current()?.lang ?? 'en';
-    return this.i18n.translate(key, { lang, args }) as string;
-  }
 
   private normalizeTitle(title: string): string {
     return (title || '')
@@ -40,11 +33,11 @@ export class ChallengesService {
     const normalizedTitle = this.normalizeTitle(title);
     const exact = await this.model.findOne({ title }).lean().exec();
     if (exact && String((exact as any)._id) !== String(ignoreId || '')) {
-      throw new ConflictException(this.tr('challenges.titleExists', { title }));
+      throw new ConflictException(`A challenge with the title '${title}' already exists. Please use a unique title.`);
     }
     const normalized = await this.model.findOne({ normalizedTitle }).lean().exec();
     if (normalized && String((normalized as any)._id) !== String(ignoreId || '')) {
-      throw new ConflictException(this.tr('challenges.titleExists', { title }));
+      throw new ConflictException(`A challenge with the title '${title}' already exists. Please use a unique title.`);
     }
     const descriptionPrefix = this.normalizeDescriptionPrefix(dto.description || '');
     if (!descriptionPrefix) return [];
@@ -53,9 +46,7 @@ export class ChallengesService {
       if (String(doc?._id) === String(ignoreId || '')) return false;
       return this.normalizeDescriptionPrefix(doc?.description || '') === descriptionPrefix;
     });
-    return similar
-      ? [this.tr('challenges.duplicateDescriptionWarning', { title: String(similar.title) })]
-      : [];
+    return similar ? [`Potential duplicate description detected with "${similar.title}".`] : [];
   }
 
   async create(dto: CreateChallengeDto): Promise<Challenge> {
@@ -77,14 +68,14 @@ export class ChallengesService {
 
   async findOne(id: string): Promise<Challenge> {
     const found = await this.model.findById(id).exec();
-    if (!found) throw new NotFoundException(this.tr('challenges.notFoundById', { id }));
+    if (!found) throw new NotFoundException(`Challenge with id ${id} not found`);
     return found;
   }
 
   async findPublishedById(id: string): Promise<Challenge> {
     const found = await this.model.findById(id).exec();
     if (!found || found.status !== 'published') {
-      throw new NotFoundException(this.tr('challenges.publishedNotFound', { id }));
+      throw new NotFoundException(`Published challenge with id ${id} not found`);
     }
     return found;
   }
@@ -92,7 +83,7 @@ export class ChallengesService {
   async update(id: string, dto: UpdateChallengeDto): Promise<Challenge> {
     if (dto.title || dto.description) {
       const existing = await this.model.findById(id).lean().exec();
-      if (!existing) throw new NotFoundException(this.tr('challenges.notFoundById', { id }));
+      if (!existing) throw new NotFoundException(`Challenge with id ${id} not found`);
       await this.ensureChallengeUniqueness({
         ...(existing as any),
         ...dto,
@@ -108,12 +99,12 @@ export class ChallengesService {
       },
       { new: true },
     ).exec();
-    if (!updated) throw new NotFoundException(this.tr('challenges.notFoundById', { id }));
+    if (!updated) throw new NotFoundException(`Challenge with id ${id} not found`);
     return updated;
   }
 
   async remove(id: string): Promise<void> {
     const deleted = await this.model.findByIdAndDelete(id).exec();
-    if (!deleted) throw new NotFoundException(this.tr('challenges.notFoundById', { id }));
+    if (!deleted) throw new NotFoundException(`Challenge with id ${id} not found`);
   }
 }

--- a/src/code-executor/code-executor.controller.ts
+++ b/src/code-executor/code-executor.controller.ts
@@ -1,24 +1,15 @@
 import { Controller, Post, Body, BadRequestException } from '@nestjs/common';
-import { I18nContext, I18nService } from 'nestjs-i18n';
 import { CodeExecutorService } from './code-executor.service';
 
 @Controller('api')
 export class CodeExecutorController {
-    constructor(
-        private readonly executor: CodeExecutorService,
-        private readonly i18n: I18nService,
-    ) {}
-
-    private tr(key: string): string {
-        const lang = I18nContext.current()?.lang ?? 'en';
-        return this.i18n.translate(key, { lang }) as string;
-    }
+    constructor(private readonly executor: CodeExecutorService) {}
 
     @Post('execute')
     async execute(@Body() body: any) {
         const { code, language, testCases } = body || {};
-        if (!code) throw new BadRequestException(this.tr('codeExecutor.codeRequired'));
-        if (!language) throw new BadRequestException(this.tr('codeExecutor.languageRequired'));
+        if (!code) throw new BadRequestException('code is required');
+        if (!language) throw new BadRequestException('language is required');
 
         try {
             if (Array.isArray(testCases) && testCases.length > 0) {

--- a/src/judge/judge.controller.ts
+++ b/src/judge/judge.controller.ts
@@ -1,5 +1,4 @@
 import { Controller, Post, Body, BadRequestException, Logger, UseGuards, Get, Param, Req } from '@nestjs/common';
-import { I18nContext, I18nService } from 'nestjs-i18n';
 import { JudgeService } from './judge.service';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
@@ -9,15 +8,7 @@ import type { Request } from 'express';
 export class JudgeController {
   private readonly logger = new Logger(JudgeController.name);
 
-  constructor(
-    private readonly judgeService: JudgeService,
-    private readonly i18n: I18nService,
-  ) {}
-
-  private tr(key: string): string {
-    const lang = I18nContext.current()?.lang ?? 'en';
-    return this.i18n.translate(key, { lang }) as string;
-  }
+  constructor(private readonly judgeService: JudgeService) {}
 
   @UseGuards(JwtAuthGuard)
   @Post('submit')
@@ -34,7 +25,7 @@ export class JudgeController {
     @Req() req: Request,
   ) {
     if (!body.challengeId || !body.userCode || !body.language) {
-      throw new BadRequestException(this.tr('judge.fieldsRequired'));
+      throw new BadRequestException("challengeId, userCode, and language are required fields.");
     }
     return this.judgeService.judgeSubmission(
       user.userId,
@@ -57,7 +48,7 @@ export class JudgeController {
     },
   ) {
     if (!body.challengeId) {
-      throw new BadRequestException(this.tr('judge.challengeIdRequired'));
+      throw new BadRequestException("challengeId is required.");
     }
     return this.judgeService.getHint(body.challengeId, body.attemptCount || 0, body.elapsedTimeSeconds || 0);
   }

--- a/src/judge/judge.service.ts
+++ b/src/judge/judge.service.ts
@@ -1,5 +1,4 @@
 import { Injectable, Logger, BadRequestException } from '@nestjs/common';
-import { I18nContext, I18nService } from 'nestjs-i18n';
 import { DockerExecutionService } from './services/docker-execution.service';
 import { AIAnalysisService } from './services/ai-analysis.service';
 import { ChallengeService } from '../challenges/challenge.service';
@@ -16,13 +15,7 @@ export class JudgeService {
     private readonly challengeService: ChallengeService,
     private readonly userService: UserService,
     private readonly auditLogService: AuditLogService,
-    private readonly i18n: I18nService,
   ) {}
-
-  private tr(key: string): string {
-    const lang = I18nContext.current()?.lang ?? 'en';
-    return this.i18n.translate(key, { lang }) as string;
-  }
 
   async startChallengeAttempt(userId: string, challengeId: string, ipAddress?: string | null) {
     const challenge = await this.challengeService.findById(challengeId);
@@ -199,12 +192,12 @@ export class JudgeService {
   ) {
     const startedAt = Date.now();
     if (language !== 'javascript' && language !== 'python') {
-      throw new BadRequestException(this.tr('judge.unsupportedLanguage'));
+      throw new BadRequestException("Unsupported language. Only 'javascript' and 'python' are allowed.");
     }
 
     const challenge = await this.challengeService.findById(challengeId);
     if (!challenge) {
-      throw new BadRequestException(this.tr('judge.challengeNotFound'));
+      throw new BadRequestException("Challenge not found.");
     }
     const existingProgress = await this.userService.getChallengeProgressEntry(userId, challengeId);
     if (mode === 'submit' && existingProgress?.status === 'SOLVED') {
@@ -214,7 +207,7 @@ export class JudgeService {
         success: true,
         passed: true,
         alreadySolved: true,
-        message: this.tr('judge.alreadySolved'),
+        message: 'Challenge already solved. Resubmission is disabled.',
         previousSubmission: latest,
         solveTimeSeconds: existingProgress.solveTimeSeconds ?? null,
       };
@@ -253,7 +246,7 @@ export class JudgeService {
         results: [],
         error: {
           type: "SyntaxError",
-          message: aiCheck.errorMessage || this.tr('judge.syntaxError'),
+          message: aiCheck.errorMessage || "Syntax Error detected.",
           line: aiCheck.errorLine
         },
         source: 'ai-syntax-check',
@@ -290,7 +283,7 @@ export class JudgeService {
         results: [],
         error: {
           type: "SyntaxError",
-          message: aiCheck.errorMessage || this.tr('judge.syntaxError'),
+          message: aiCheck.errorMessage || "Syntax Error detected.",
           line: aiCheck.errorLine
         },
         aiAnalysis: "Syntax error prevented execution. Please fix and try again.",
@@ -518,7 +511,7 @@ export class JudgeService {
   async getHint(challengeId: string, attemptCount: number, elapsedTimeSeconds: number) {
     const challenge = await this.challengeService.findById(challengeId);
     if (!challenge) {
-      throw new BadRequestException(this.tr('judge.challengeNotFound'));
+      throw new BadRequestException("Challenge not found.");
     }
 
     const isUnlocked = attemptCount >= 3 || elapsedTimeSeconds >= 300;

--- a/src/judge/services/docker-execution.service.ts
+++ b/src/judge/services/docker-execution.service.ts
@@ -1,5 +1,4 @@
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
-import { I18nContext, I18nService } from 'nestjs-i18n';
 import { InjectModel } from '@nestjs/mongoose';
 import { promises as fs } from 'node:fs';
 import os from 'node:os';
@@ -69,15 +68,7 @@ export class DockerExecutionService implements OnModuleInit {
   private readonly cpuLimitNano = 500_000_000;
   private readonly timeoutMs = 3000;
 
-  constructor(
-    @InjectModel('SandboxMetric') private readonly sandboxMetricModel: Model<any>,
-    private readonly i18n: I18nService,
-  ) {}
-
-  private tr(key: string, args?: Record<string, unknown>): string {
-    const lang = I18nContext.current()?.lang ?? 'en';
-    return this.i18n.translate(key, { lang, args }) as string;
-  }
+  constructor(@InjectModel('SandboxMetric') private readonly sandboxMetricModel: Model<any>) {}
 
   async onModuleInit() {
     const available = await this.isDockerAvailable();
@@ -102,7 +93,7 @@ export class DockerExecutionService implements OnModuleInit {
         executionTimeMs: Date.now() - startedAt,
         error: {
           type: 'ServiceUnavailable',
-          message: this.tr('docker.unavailable'),
+          message: 'Docker sandbox execution is unavailable. Start Docker Desktop and try again.',
           line: null,
         },
       };
@@ -119,7 +110,7 @@ export class DockerExecutionService implements OnModuleInit {
         executionTimeMs: Date.now() - startedAt,
         error: {
           type: 'SyntaxError',
-          message: this.tr('docker.noFunction'),
+          message: 'No function definition found. Define a callable function and try again.',
           line: null,
         },
       };
@@ -253,7 +244,7 @@ export class DockerExecutionService implements OnModuleInit {
           executionTimeMs: Date.now() - startedAt,
           error: {
             type: 'TimeoutError',
-            message: this.tr('docker.timeout', { ms: this.timeoutMs }),
+            message: `Execution exceeded ${this.timeoutMs}ms and was terminated.`,
             line: null,
           },
         };
@@ -274,7 +265,7 @@ export class DockerExecutionService implements OnModuleInit {
           executionTimeMs: Date.now() - startedAt,
           error: {
             type: 'SystemError',
-            message: this.tr('docker.unreadableResult'),
+            message: 'Execution completed but produced an unreadable result payload.',
             line: null,
           },
         };
@@ -297,7 +288,7 @@ export class DockerExecutionService implements OnModuleInit {
             expectedOutput: testCase.expected,
             actualOutput: null,
             passed: false,
-            error: this.tr('docker.noResultForCase'),
+            error: 'No execution result returned for this test case.',
             executionTimeMs: 0,
             executionTime: '0ms',
           };
@@ -349,7 +340,7 @@ export class DockerExecutionService implements OnModuleInit {
         executionTimeMs: Date.now() - startedAt,
         error: {
           type: 'ExecutionError',
-          message: error?.message || this.tr('docker.unexpectedFailure'),
+          message: error?.message || 'Unexpected execution failure.',
           line: null,
         },
       };
@@ -437,7 +428,7 @@ export class DockerExecutionService implements OnModuleInit {
         data: [],
         error: {
           type: 'InputParseError',
-          message: error?.message || this.tr('docker.parseTestInput'),
+          message: error?.message || 'Unable to parse challenge test-case input.',
           line: null,
         },
       };

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,33 +1,13 @@
 import { NestFactory } from '@nestjs/core';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import { AppModule } from './app.module';
-import { I18nValidationPipe } from 'nestjs-i18n';
+import { ValidationPipe } from '@nestjs/common';
 import cookieParser from 'cookie-parser';
 import { join } from 'path';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
-import { WsAdapter } from '@nestjs/platform-ws';
-
-function swaggerDocsMessage(req: { headers?: Record<string, string | string[] | undefined> }, key: 'unauthorized' | 'forbidden' | 'invalidToken'): string {
-  const raw = req.headers?.['accept-language'];
-  const al = Array.isArray(raw) ? raw[0] : raw;
-  const fr = String(al || '').toLowerCase().startsWith('fr');
-  const messages = {
-    unauthorized: fr
-      ? 'Non autorisé à consulter la documentation API'
-      : 'Unauthorized to view API Docs',
-    forbidden: fr
-      ? 'Interdit : accès réservé aux administrateurs / développeurs'
-      : 'Forbidden: Admin/Dev access only',
-    invalidToken: fr
-      ? 'Jeton invalide pour l’accès à la documentation API'
-      : 'Invalid token for API Docs access',
-  };
-  return messages[key];
-}
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule);
-  app.useWebSocketAdapter(new WsAdapter(app));
   const allowedOrigins = (process.env.CORS_ORIGIN ?? 'http://localhost:5173')
     .split(',')
     .map((origin) => origin.trim())
@@ -36,16 +16,11 @@ async function bootstrap() {
   app.enableCors({
     origin: allowedOrigins,
     methods: ['GET', 'HEAD', 'PUT', 'PATCH', 'POST', 'DELETE', 'OPTIONS'],
-    allowedHeaders: ['Content-Type', 'Authorization', 'Accept-Language'],
+    allowedHeaders: ['Content-Type', 'Authorization'],
     credentials: true,
   });
 
-  app.useGlobalPipes(
-    new I18nValidationPipe({
-      whitelist: true,
-      transform: true,
-    }),
-  );
+  app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
   app.use(cookieParser());
   app.useStaticAssets(join(process.cwd(), 'uploads'), { prefix: '/uploads' });
 
@@ -61,16 +36,16 @@ async function bootstrap() {
   app.use('/api/docs', (req: any, res: any, next: any) => {
     if (process.env.NODE_ENV === 'production') {
       const token = req.cookies?.access_token || req.cookies?.refresh_token;
-      if (!token) return res.status(401).send(swaggerDocsMessage(req, 'unauthorized'));
+      if (!token) return res.status(401).send('Unauthorized to view API Docs');
       try {
         const payload = JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString());
         // Assuming roles are uppercase 'ADMIN', 'ORGANIZER' or similar
         const role = (payload.role || '').toUpperCase();
         if (role !== 'ADMIN' && role !== 'SUPER_ADMIN' && role !== 'DEV') {
-          return res.status(403).send(swaggerDocsMessage(req, 'forbidden'));
+          return res.status(403).send('Forbidden: Admin/Dev access only');
         }
       } catch (e) {
-        return res.status(401).send(swaggerDocsMessage(req, 'invalidToken'));
+        return res.status(401).send('Invalid token for API Docs access');
       }
     }
     next();

--- a/src/onboarding/onboarding.service.ts
+++ b/src/onboarding/onboarding.service.ts
@@ -1,5 +1,4 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { I18nContext, I18nService } from 'nestjs-i18n';
 import { ConfigService } from '@nestjs/config';
 import { SettingsService } from '../settings/settings.service';
 import { CacheService } from '../cache/cache.service';
@@ -53,6 +52,14 @@ const RANK_TIERS = [
   { min: 0, rank: 'BRONZE', label: 'Bronze', color: '#cd7f32', gradient: ['#cd7f32', '#a0522d'] as [string, string], xp: 0 },
 ];
 
+const RANK_MESSAGES: Record<string, string> = {
+  DIAMOND: 'Exceptional! Your code correctness, efficiency and style are top-tier.',
+  PLATINUM: 'Outstanding! Clean, efficient solutions delivered at pace.',
+  GOLD: 'Solid work! Good correctness with room to further optimise.',
+  SILVER: 'Good effort — keep sharpening your problem-solving instincts.',
+  BRONZE: 'Every expert started somewhere — keep coding every day!',
+};
+
 // Starter code snippets to detect empty submissions
 const STARTER_TOKENS = [
   '// your solution here',
@@ -75,21 +82,11 @@ export class OnboardingService {
     private readonly settingsService: SettingsService,
     private readonly configService: ConfigService,
     private readonly cacheService: CacheService,
-    private readonly i18n: I18nService,
     private readonly aiAnalysisService: AIAnalysisService,
   ) {
     if (!this.groqApiKey) {
       this.logger.warn('GROQ_API_KEY not set — AI scoring will be disabled');
     }
-  }
-
-  private tr(key: string, args?: Record<string, unknown>): string {
-    const lang = I18nContext.current()?.lang ?? 'en';
-    return this.i18n.translate(key, { lang, args }) as string;
-  }
-
-  private rankMessage(rank: string): string {
-    return this.tr(`onboarding.rankMessages.${rank}`);
   }
 
   async generateSpeedChallengeHint(title: string, description: string, hintLevel = 1): Promise<string> {
@@ -159,7 +156,7 @@ export class OnboardingService {
         space: Math.round(avgSpace),
         style: Math.round(avgStyle),
       },
-      message: this.rankMessage(tier.rank),
+      message: RANK_MESSAGES[tier.rank],
     };
   }
 
@@ -190,7 +187,7 @@ export class OnboardingService {
       complexite: 'O(?)',
       style: s.solved ? 50 : 0,
       composite: s.solved ? baseScore : 0,
-      notes: s.solved ? this.tr('onboarding.ruleBasedNotesSolved') : this.tr('onboarding.ruleBasedNotesNotSolved'),
+      notes: s.solved ? 'Rule-based estimate (AI classification disabled).' : 'Not solved.',
     }));
 
     return {
@@ -202,7 +199,7 @@ export class OnboardingService {
       totalScore: baseScore,
       breakdown,
       aiScores: { exactitude: baseScore, complexity: 50, space: 50, style: 50 },
-      message: this.rankMessage(tier.rank) + this.tr('onboarding.aiDisabledSuffix'),
+      message: RANK_MESSAGES[tier.rank] + ' (AI classification disabled)',
     };
   }
 
@@ -215,7 +212,7 @@ export class OnboardingService {
       STARTER_TOKENS.some((t) => sol.code.toLowerCase().includes(t));
 
     if (!sol.solved || isEmpty) {
-      return this.zeroScore(sol, this.tr('onboarding.notSolvedOrEmpty'));
+      return this.zeroScore(sol, 'Problem not solved or no meaningful code submitted.');
     }
 
     try {

--- a/src/settings/guards/maintenance.guard.ts
+++ b/src/settings/guards/maintenance.guard.ts
@@ -5,7 +5,6 @@ import {
   ServiceUnavailableException,
 } from '@nestjs/common';
 import { SettingsService } from '../settings.service';
-import { I18nContext, I18nService } from 'nestjs-i18n';
 
 /** Route prefixes that are always allowed, even in maintenance mode */
 const ALLOWED_PREFIXES = ['/auth', '/settings'];
@@ -14,10 +13,7 @@ const ALLOWED_EXACT = ['/user/me'];
 
 @Injectable()
 export class MaintenanceGuard implements CanActivate {
-  constructor(
-    private readonly settingsService: SettingsService,
-    private readonly i18n: I18nService,
-  ) {}
+  constructor(private readonly settingsService: SettingsService) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest();
@@ -42,9 +38,8 @@ export class MaintenanceGuard implements CanActivate {
       return true;
     }
 
-    const lang = I18nContext.current()?.lang ?? 'en';
     throw new ServiceUnavailableException(
-      this.i18n.translate('maintenance.serviceUnavailable', { lang }) as string,
+      'Service is under maintenance. Please try again later.',
     );
   }
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -32,7 +32,6 @@ import { UpdateStatusDto } from './dto/update-status.dto';
 import { UpdatePlacementDto } from './dto/update-placement.dto';
 import { SaveSpeedTestSessionDto } from './dto/save-speed-test-session.dto';
 import { AuditLogService } from '../audit-logs/audit-log.service';
-import { I18nContext, I18nService } from 'nestjs-i18n';
 
 // Rank order for promo/demotion direction checks
 const RANK_ORDER = ['BRONZE', 'SILVER', 'GOLD', 'PLATINUM', 'DIAMOND', 'RUBY', 'EMERALD', 'SAPPHIRE', 'OBSIDIAN', 'ALGOARENA CHAMPION'];
@@ -71,13 +70,7 @@ export class UserController {
 	constructor(
 		private readonly userService: UserService,
 		private readonly auditLogService: AuditLogService,
-		private readonly i18n: I18nService,
-	) {}
-
-	private tr(key: string, args?: Record<string, unknown>): string {
-		const lang = I18nContext.current()?.lang ?? 'en';
-		return this.i18n.translate(key, { lang, args }) as string;
-	}
+	) { }
 
 	private safeDebugLog(obj: any) {
 		try {
@@ -226,7 +219,7 @@ Audit logs are created for every call:
 	) {
 		const xpDelta = Number(body?.xpDelta);
 		if (!isFinite(xpDelta)) {
-			throw new BadRequestException(this.tr('userController.xpDeltaInvalid'));
+			throw new BadRequestException('xpDelta must be a finite number');
 		}
 
 		const result = await this.userService.updateXpAndRank(user.userId, xpDelta);
@@ -284,7 +277,7 @@ Audit logs are created for every call:
 		@UploadedFile() file: Express.Multer.File,
 	) {
 		if (!file) {
-			throw new BadRequestException(this.tr('userController.avatarRequired'));
+			throw new BadRequestException('Avatar file is required');
 		}
 		return this.userService.updateAvatar(user.userId, file.filename);
 	}
@@ -323,7 +316,7 @@ Audit logs are created for every call:
 	@HttpCode(HttpStatus.OK)
 	async completeSpeedChallenge(@CurrentUser() user: { userId: string }) {
 		await this.userService.completeSpeedChallenge(user.userId);
-		return { message: this.tr('user.speedChallengeCompleted') };
+		return { message: 'Speed challenge completed' };
 	}
 
 	@UseGuards(JwtAuthGuard)
@@ -337,7 +330,7 @@ Audit logs are created for every call:
 		@Body() sessionData: SaveSpeedTestSessionDto,
 	) {
 		await this.userService.saveSpeedTestSession(user.userId, sessionData);
-		return { message: this.tr('user.sessionSaved') };
+		return { message: 'Session saved' };
 	}
 
 	@UseGuards(JwtAuthGuard)
@@ -347,7 +340,7 @@ Audit logs are created for every call:
 	@Get('me/speed-challenge/session')
 	async getSpeedTestSession(@CurrentUser() user: { userId: string }) {
 		const session = await this.userService.getSpeedTestSession(user.userId);
-		return session || { message: this.tr('user.noOngoingSession') };
+		return session || { message: 'No ongoing session' };
 	}
 
 	@UseGuards(JwtAuthGuard)
@@ -358,7 +351,7 @@ Audit logs are created for every call:
 	@HttpCode(HttpStatus.OK)
 	async clearSpeedTestSession(@CurrentUser() user: { userId: string }) {
 		await this.userService.clearSpeedTestSession(user.userId);
-		return { message: this.tr('user.sessionCleared') };
+		return { message: 'Session cleared' };
 	}
 
 	@UseGuards(JwtAuthGuard)
@@ -409,7 +402,7 @@ Audit logs are created for every call:
 			});
 			return result;
 		} catch (err) {
-			throw new HttpException(this.tr('userController.failedCreateAdmin'), HttpStatus.BAD_REQUEST);
+			throw new HttpException('Failed to create admin', HttpStatus.BAD_REQUEST);
 		}
 	}
 
@@ -420,7 +413,7 @@ Audit logs are created for every call:
 		try {
 			return await this.userService.create(dto);
 		} catch (err) {
-			throw new HttpException(this.tr('userController.failedCreateUser'), HttpStatus.BAD_REQUEST);
+			throw new HttpException('Failed to create user', HttpStatus.BAD_REQUEST);
 		}
 	}
 
@@ -467,7 +460,7 @@ Audit logs are created for every call:
 		@UploadedFile() file: Express.Multer.File,
 	) {
 		if (!file) {
-			throw new BadRequestException(this.tr('userController.avatarRequired'));
+			throw new BadRequestException('Avatar file is required');
 		}
 		return this.userService.updateAvatar(id, file.filename);
 	}

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -5,7 +5,6 @@ import {
   ConflictException,
   UnauthorizedException,
 } from '@nestjs/common';
-import { I18nContext, I18nService } from 'nestjs-i18n';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { Types } from 'mongoose';
@@ -102,15 +101,7 @@ const getRankDefinition = (rankName: string | null | undefined) => {
 
 @Injectable()
 export class UserService {
-  constructor(
-    @InjectModel('User') private userModel: Model<any>,
-    private readonly i18n: I18nService,
-  ) {}
-
-  private tr(key: string, args?: Record<string, unknown>): string {
-    const lang = I18nContext.current()?.lang ?? 'en';
-    return this.i18n.translate(key, { lang, args }) as string;
-  }
+  constructor(@InjectModel('User') private userModel: Model<any>) { }
 
   private utcDateOnly(value: Date = new Date()): Date {
     return new Date(Date.UTC(value.getUTCFullYear(), value.getUTCMonth(), value.getUTCDate()));
@@ -147,7 +138,7 @@ export class UserService {
 
   private ensureValidObjectId(id: string) {
     if (!id || !/^[a-fA-F0-9]{24}$/.test(id) || !Types.ObjectId.isValid(id)) {
-      throw new BadRequestException(this.tr('user.invalidId'));
+      throw new BadRequestException('Invalid user id');
     }
   }
 
@@ -178,7 +169,7 @@ export class UserService {
   async findOne(id: string) {
     this.ensureValidObjectId(id);
     const user = await this.userModel.findById(id).lean().exec();
-    if (!user) throw new NotFoundException(this.tr('user.notFound'));
+    if (!user) throw new NotFoundException('User not found');
     return user;
   }
 
@@ -193,7 +184,7 @@ export class UserService {
     if (partial.password) update.passwordHash = crypto.createHash('sha256').update(partial.password).digest('hex');
 
     const updated = await this.userModel.findByIdAndUpdate(id, update, { new: true }).lean().exec();
-    if (!updated) throw new NotFoundException(this.tr('user.notFound'));
+    if (!updated) throw new NotFoundException('User not found');
     return updated;
   }
 
@@ -202,7 +193,7 @@ export class UserService {
   async getMyProfile(userId: string): Promise<any> {
     this.ensureValidObjectId(userId);
     const user = await this.userModel.findById(userId).lean().exec();
-    if (!user) throw new NotFoundException(this.tr('user.notFound'));
+    if (!user) throw new NotFoundException('User not found');
 
     const { passwordHash: _omit, ...rest } = user as any;
     const rankStats = await this.getRankStats(userId);
@@ -232,7 +223,7 @@ export class UserService {
     const todayToken = this.dateToken(today);
 
     const user = await this.userModel.findById(userId).lean().exec() as any;
-    if (!user) throw new NotFoundException(this.tr('user.notFound'));
+    if (!user) throw new NotFoundException('User not found');
 
     const lastLoginDateRaw = user.lastLoginDate ? new Date(user.lastLoginDate) : null;
     const lastLoginDay = lastLoginDateRaw ? this.utcDateOnly(lastLoginDateRaw) : null;
@@ -334,7 +325,7 @@ export class UserService {
   }> {
     this.ensureValidObjectId(userId);
     const user = await this.userModel.findById(userId).lean().exec() as any;
-    if (!user) throw new NotFoundException(this.tr('user.notFound'));
+    if (!user) throw new NotFoundException('User not found');
 
     const xp: number = Number(user.xp ?? 0);
     const calculatedRank = xpToRank(xp);
@@ -414,7 +405,7 @@ export class UserService {
   }> {
     this.ensureValidObjectId(userId);
     const user = await this.userModel.findById(userId).lean().exec() as any;
-    if (!user) throw new NotFoundException(this.tr('user.notFound'));
+    if (!user) throw new NotFoundException('User not found');
 
     const previousXp: number = user.xp ?? 0;
     const previousRank: string | null = user.rank ?? null;
@@ -449,7 +440,7 @@ export class UserService {
   async getChallengeProgress(userId: string): Promise<any[]> {
     this.ensureValidObjectId(userId);
     const user = await this.userModel.findById(userId).lean().exec() as any;
-    if (!user) throw new NotFoundException(this.tr('user.notFound'));
+    if (!user) throw new NotFoundException('User not found');
     return Array.isArray(user.challengeProgress) ? user.challengeProgress : [];
   }
 
@@ -539,7 +530,7 @@ export class UserService {
   ) {
     this.ensureValidObjectId(userId);
     const user = await this.userModel.findById(userId).lean().exec() as any;
-    if (!user) throw new NotFoundException(this.tr('user.notFound'));
+    if (!user) throw new NotFoundException('User not found');
 
     const challengeProgressRaw = Array.isArray(user.challengeProgress) ? [...user.challengeProgress] : [];
     const { changed, next } = this.syncInactivityLifecycle(challengeProgressRaw);
@@ -621,7 +612,7 @@ export class UserService {
   ) {
     this.ensureValidObjectId(userId);
     const user = await this.userModel.findById(userId).lean().exec() as any;
-    if (!user) throw new NotFoundException(this.tr('user.notFound'));
+    if (!user) throw new NotFoundException('User not found');
 
     const challengeProgressRaw = Array.isArray(user.challengeProgress) ? [...user.challengeProgress] : [];
     const { next } = this.syncInactivityLifecycle(challengeProgressRaw);
@@ -688,7 +679,7 @@ export class UserService {
   ) {
     this.ensureValidObjectId(userId);
     const user = await this.userModel.findById(userId).lean().exec() as any;
-    if (!user) throw new NotFoundException(this.tr('user.notFound'));
+    if (!user) throw new NotFoundException('User not found');
     const challengeProgressRaw = Array.isArray(user.challengeProgress) ? [...user.challengeProgress] : [];
     const { next } = this.syncInactivityLifecycle(challengeProgressRaw);
     const challengeProgress = next;
@@ -720,7 +711,7 @@ export class UserService {
   async returnChallengeAttempt(userId: string, challengeId: string) {
     this.ensureValidObjectId(userId);
     const user = await this.userModel.findById(userId).lean().exec() as any;
-    if (!user) throw new NotFoundException(this.tr('user.notFound'));
+    if (!user) throw new NotFoundException('User not found');
 
     const challengeProgressRaw = Array.isArray(user.challengeProgress) ? [...user.challengeProgress] : [];
     const { next } = this.syncInactivityLifecycle(challengeProgressRaw);
@@ -760,7 +751,7 @@ export class UserService {
   async expireChallengeAttempt(userId: string, challengeId: string) {
     this.ensureValidObjectId(userId);
     const user = await this.userModel.findById(userId).lean().exec() as any;
-    if (!user) throw new NotFoundException(this.tr('user.notFound'));
+    if (!user) throw new NotFoundException('User not found');
     const challengeProgress = Array.isArray(user.challengeProgress) ? [...user.challengeProgress] : [];
     const index = challengeProgress.findIndex((entry: any) => entry.challengeId === challengeId);
     if (index < 0) return { updated: false, status: 'UNSOLVED' };
@@ -778,7 +769,7 @@ export class UserService {
   async getUserAttempts(userId: string) {
     this.ensureValidObjectId(userId);
     const user = await this.userModel.findById(userId).lean().exec() as any;
-    if (!user) throw new NotFoundException(this.tr('user.notFound'));
+    if (!user) throw new NotFoundException('User not found');
     const progressRaw = Array.isArray(user.challengeProgress) ? user.challengeProgress : [];
     const { changed, next: progress } = this.syncInactivityLifecycle(progressRaw);
     if (changed) {
@@ -814,7 +805,7 @@ export class UserService {
   ): Promise<{ progressEntry: any; xpGranted: number }> {
     this.ensureValidObjectId(userId);
     const user = await this.userModel.findById(userId).lean().exec() as any;
-    if (!user) throw new NotFoundException(this.tr('user.notFound'));
+    if (!user) throw new NotFoundException('User not found');
 
     const challengeProgress = Array.isArray(user.challengeProgress) ? [...user.challengeProgress] : [];
     const index = challengeProgress.findIndex((entry: any) => entry.challengeId === challengeId);
@@ -899,7 +890,7 @@ export class UserService {
   async updateAvatar(userId: string, filename: string): Promise<{ message: string; avatarUrl: string }> {
     this.ensureValidObjectId(userId);
     const user = await this.userModel.findById(userId).lean().exec();
-    if (!user) throw new NotFoundException(this.tr('user.notFound'));
+    if (!user) throw new NotFoundException('User not found');
 
     if ((user as any).avatar) {
       const oldPath = join(process.cwd(), (user as any).avatar);
@@ -910,28 +901,28 @@ export class UserService {
     const updated = await this.userModel
       .findByIdAndUpdate(userId, { avatar: avatarPath }, { new: true })
       .lean().exec();
-    if (!updated) throw new NotFoundException(this.tr('user.notFound'));
+    if (!updated) throw new NotFoundException('User not found');
 
-    return { message: this.tr('user.avatarUpdated'), avatarUrl: avatarPath };
+    return { message: 'Avatar updated successfully', avatarUrl: avatarPath };
   }
 
   async updateProfile(userId: string, dto: UpdateProfileDto): Promise<any> {
     this.ensureValidObjectId(userId);
     if (dto.username === undefined && dto.email === undefined && dto.bio === undefined) {
-      throw new BadRequestException(this.tr('user.updateRequiresField'));
+      throw new BadRequestException('At least one field is required: username, email, or bio');
     }
 
     if (dto.username) {
       const conflict = await this.userModel.findOne({ username: dto.username }).lean().exec();
       if (conflict && (conflict as any)._id.toString() !== userId) {
-        throw new ConflictException(this.tr('user.usernameTaken'));
+        throw new ConflictException('Username already taken');
       }
     }
 
     if (dto.email) {
       const conflict = await this.userModel.findOne({ email: dto.email }).lean().exec();
       if (conflict && (conflict as any)._id.toString() !== userId) {
-        throw new ConflictException(this.tr('user.emailInUse'));
+        throw new ConflictException('Email already in use');
       }
     }
 
@@ -943,7 +934,7 @@ export class UserService {
     const updated = await this.userModel
       .findByIdAndUpdate(userId, update, { new: true })
       .lean().exec();
-    if (!updated) throw new NotFoundException(this.tr('user.notFound'));
+    if (!updated) throw new NotFoundException('User not found');
 
     const { passwordHash: _omit, ...rest } = updated as any;
     return rest;
@@ -959,7 +950,7 @@ export class UserService {
   async updatePlacement(userId: string, dto: UpdatePlacementDto, force = false): Promise<any> {
     this.ensureValidObjectId(userId);
     const user = await this.userModel.findById(userId).lean().exec() as any;
-    if (!user) throw new NotFoundException(this.tr('user.notFound'));
+    if (!user) throw new NotFoundException('User not found');
 
     if (user.rank && !force) {
       const { passwordHash: _omit, ...rest } = user;
@@ -1037,21 +1028,21 @@ export class UserService {
   async changePassword(userId: string, dto: ChangePasswordDto): Promise<{ message: string }> {
     this.ensureValidObjectId(userId);
     const user = await this.userModel.findById(userId).lean().exec();
-    if (!user) throw new NotFoundException(this.tr('user.notFound'));
+    if (!user) throw new NotFoundException('User not found');
 
     if (dto.newPassword !== dto.confirmPassword) {
-      throw new BadRequestException(this.tr('user.passwordMismatch'));
+      throw new BadRequestException('newPassword and confirmPassword do not match');
     }
 
     const currentHash = crypto.createHash('sha256').update(dto.currentPassword).digest('hex');
     if ((user as any).passwordHash !== currentHash) {
-      throw new BadRequestException(this.tr('user.currentPasswordIncorrect'));
+      throw new BadRequestException('Current password is incorrect');
     }
 
     const newHash = crypto.createHash('sha256').update(dto.newPassword).digest('hex');
     await this.userModel.findByIdAndUpdate(userId, { passwordHash: newHash }).exec();
 
-    return { message: this.tr('user.passwordUpdated') };
+    return { message: 'Password updated successfully' };
   }
 
   async updateStatus(id: string, status: boolean): Promise<any> {
@@ -1059,7 +1050,7 @@ export class UserService {
     const updated = await this.userModel
       .findByIdAndUpdate(id, { status }, { new: true })
       .lean().exec();
-    if (!updated) throw new NotFoundException(this.tr('user.notFound'));
+    if (!updated) throw new NotFoundException('User not found');
 
     const { passwordHash: _omit, ...rest } = updated as any;
     return rest;
@@ -1068,11 +1059,11 @@ export class UserService {
   async deleteAccount(userId: string, dto: DeleteAccountDto): Promise<{ message: string }> {
     this.ensureValidObjectId(userId);
     const user = await this.userModel.findById(userId).lean().exec();
-    if (!user) throw new NotFoundException(this.tr('user.notFound'));
+    if (!user) throw new NotFoundException('User not found');
 
     const hash = crypto.createHash('sha256').update(dto.password).digest('hex');
     if ((user as any).passwordHash !== hash) {
-      throw new UnauthorizedException(this.tr('user.invalidPassword'));
+      throw new UnauthorizedException('Invalid password');
     }
 
     if ((user as any).avatar) {
@@ -1081,7 +1072,7 @@ export class UserService {
     }
 
     await this.userModel.findByIdAndDelete(userId).exec();
-    return { message: this.tr('user.accountDeleted') };
+    return { message: 'Account deleted successfully' };
   }
 
   // â”€â”€ Password Reset â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€


### PR DESCRIPTION
Remove nestjs-i18n usage and related translation lookups across the app, replacing localized translations with fixed English messages. Remove i18n- and websocket-related dependencies from package.json and adjust nest-cli.json assets. Implement battle expiry and XP awarding: add timeLimitSeconds, score and xp fields to Battle schema and DTO, computeBattleXp(), isExpired(), and maybeFinalizeAndAward() in BattlesService; ensure battles are finalized and XP is granted when fetched/updated. Add UserModule to BattleModule to allow XP updates. Misc: simplify Recaptcha, email deliverability and speed-challenge guard error handling/messages and clean up various auth controller/service validations and responses.