### PR TITLE
Add Battle 1vs1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "redis": "^5.11.0",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
+        "socket.io": "^4.8.3",
         "swagger-ui-express": "^5.0.1",
         "systeminformation": "^5.31.1",
         "typeorm": "^0.3.28",
@@ -3713,6 +3714,12 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
     "node_modules/@sqltools/formatter": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/@sqltools/formatter/-/formatter-1.2.5.tgz",
@@ -3861,6 +3868,15 @@
       "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/docker-modem": {
       "version": "3.0.6",
@@ -4208,6 +4224,15 @@
       "license": "MIT",
       "dependencies": {
         "@types/webidl-conversions": "*"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/yargs": {
@@ -5453,6 +5478,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "license": "MIT",
+      "engines": {
+        "node": "^4.5.0 || >= 5.9"
+      }
     },
     "node_modules/base64url": {
       "version": "3.0.1",
@@ -6713,6 +6747,100 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/engine.io": {
+      "version": "6.6.6",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.6.tgz",
+      "integrity": "sha512-U2SN0w3OpjFRVlrc17E6TMDmH58Xl9rai1MblNjAdwWp07Kk+llmzX0hjDpQdrDGzwmvOtgM5yI+meYX6iZ2xA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
+        "@types/ws": "^8.5.12",
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.7.2",
+        "cors": "~2.8.5",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.18.3"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/engine.io/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/enhanced-resolve": {
@@ -11501,6 +11629,111 @@
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socket.io": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.3.tgz",
+      "integrity": "sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "cors": "~2.8.5",
+        "debug": "~4.4.1",
+        "engine.io": "~6.6.0",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/socket.io-adapter": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.6.tgz",
+      "integrity": "sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "~4.4.1",
+        "ws": "~8.18.3"
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/socket.io/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/socket.io/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/socket.io/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/socks": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "redis": "^5.11.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
+    "socket.io": "^4.8.3",
     "swagger-ui-express": "^5.0.1",
     "systeminformation": "^5.31.1",
     "typeorm": "^0.3.28",

--- a/src/battles/battle.controller.ts
+++ b/src/battles/battle.controller.ts
@@ -12,8 +12,10 @@ import {
 } from '@nestjs/common';
 import { BattlesService } from './battle.service';
 import { BattleAiService } from './battle-ai.service';
+import { BattleGateway } from './battle.gateway';
 import { CreateBattleDto } from './dto/create-battle.dto';
 import { UpdateBattleDto } from './dto/update-battle.dto';
+import { SubmitRoundResultDto } from './dto/submit-round-result.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 
@@ -22,6 +24,7 @@ export class BattlesController {
   constructor(
     private readonly service: BattlesService,
     private readonly battleAiService: BattleAiService,
+    private readonly battleGateway: BattleGateway,
   ) {}
 
   // POST /battles - Create a new battle
@@ -44,6 +47,55 @@ export class BattlesController {
   async findMine(@CurrentUser() user: { userId: string }) {
     const battles = await this.service.findByUserId(user.userId);
     return { battles };
+  }
+
+  // GET /battles/lobby - Retrieve joinable 1vs1 battles
+  @UseGuards(JwtAuthGuard)
+  @Get('lobby')
+  async findLobby(@CurrentUser() user: { userId: string }) {
+    const battles = await this.service.findJoinableBattles(user.userId);
+    return { battles };
+  }
+
+  // POST /battles/:id/join - Join a pending 1vs1 battle
+  @UseGuards(JwtAuthGuard)
+  @Post(':id/join')
+  async joinBattle(
+    @Param('id') id: string,
+    @CurrentUser() user: { userId: string },
+  ) {
+    const battle = await this.service.joinBattle(id, user.userId);
+    this.battleGateway.emitBattleJoined({
+      battleId: String((battle as any)?._id || (battle as any)?.idBattle || id),
+      userId: String((battle as any)?.userId || ''),
+      opponentId: (battle as any)?.opponentId || null,
+      battleStatus: String((battle as any)?.battleStatus || 'ACTIVE'),
+    });
+    return battle;
+  }
+
+  // GET /battles/:id/round-results - Retrieve persisted 1vs1 round results
+  @UseGuards(JwtAuthGuard)
+  @Get(':id/round-results')
+  async getRoundResults(@Param('id') id: string) {
+    const results = await this.service.getRoundResults(id);
+    return { results };
+  }
+
+  // POST /battles/:id/round-result - Persist and broadcast 1vs1 round result
+  @UseGuards(JwtAuthGuard)
+  @Post(':id/round-result')
+  async submitRoundResult(
+    @Param('id') id: string,
+    @CurrentUser() user: { userId: string },
+    @Body() body: SubmitRoundResultDto,
+  ) {
+    const packet = await this.service.submitRoundResult(id, user.userId, {
+      roundIndex: body.roundIndex,
+      result: body.result,
+    });
+    this.battleGateway.emitBattleRoundResult(packet);
+    return packet;
   }
 
   // GET /battles/:id - Retrieve a specific battle by id

--- a/src/battles/battle.gateway.ts
+++ b/src/battles/battle.gateway.ts
@@ -1,0 +1,164 @@
+import {
+  ConnectedSocket,
+  MessageBody,
+  OnGatewayConnection,
+  OnGatewayDisconnect,
+  SubscribeMessage,
+  WebSocketGateway,
+} from '@nestjs/websockets';
+import { JwtService } from '@nestjs/jwt';
+import { Server, WebSocket } from 'ws';
+
+type SocketUser = { userId: string; username: string; role?: string };
+type AuthSocket = WebSocket & { user?: SocketUser; rooms?: Set<string> };
+
+@WebSocketGateway({
+  path: '/battles/ws',
+  cors: {
+    origin: (process.env.CORS_ORIGIN ?? 'http://localhost:5173')
+      .split(',')
+      .map((v) => v.trim()),
+    credentials: true,
+  },
+})
+export class BattleGateway implements OnGatewayConnection, OnGatewayDisconnect {
+  server: Server;
+
+  private readonly roomMembers = new Map<string, Set<AuthSocket>>();
+
+  constructor(private readonly jwtService: JwtService) {}
+
+  async handleConnection(client: AuthSocket, req: any) {
+    try {
+      const url = new URL(req.url, 'ws://localhost');
+      const tokenFromQuery = url.searchParams.get('token');
+      const authHeader = String(req.headers?.authorization || '');
+      const tokenFromHeader = authHeader.startsWith('Bearer ')
+        ? authHeader.slice(7)
+        : null;
+      const token = tokenFromQuery || tokenFromHeader;
+      if (!token) {
+        client.close(4001, 'Unauthorized');
+        return;
+      }
+      const payload = await this.jwtService.verifyAsync(token, {
+        secret: process.env.JWT_SECRET || 'defaultJwtSecret',
+      });
+      client.user = {
+        userId: String(payload.sub),
+        username: String(payload.username || 'Player'),
+        role: payload.role,
+      };
+      client.rooms = new Set();
+    } catch {
+      client.close(4001, 'Unauthorized');
+    }
+  }
+
+  handleDisconnect(client: AuthSocket) {
+    for (const roomId of client.rooms || []) {
+      this.roomMembers.get(roomId)?.delete(client);
+    }
+  }
+
+  private emit(client: AuthSocket, event: string, data: unknown) {
+    if (client.readyState === client.OPEN) {
+      client.send(JSON.stringify({ event, data }));
+    }
+  }
+
+  private emitRoom(
+    roomId: string,
+    event: string,
+    data: unknown,
+    exclude?: AuthSocket,
+  ) {
+    const members = this.roomMembers.get(roomId);
+    if (!members) return;
+    for (const member of members) {
+      if (exclude && member === exclude) continue;
+      this.emit(member, event, data);
+    }
+  }
+
+  @SubscribeMessage('watchBattle')
+  watchBattle(
+    @ConnectedSocket() client: AuthSocket,
+    @MessageBody() body: { battleId?: string },
+  ) {
+    if (!client.user)
+      return this.emit(client, 'error', { message: 'Unauthorized' });
+    const battleId = String(body?.battleId || '').trim();
+    if (!battleId)
+      return this.emit(client, 'error', { message: 'battleId is required' });
+
+    const roomId = `battle:${battleId}`;
+    if (!this.roomMembers.has(roomId)) this.roomMembers.set(roomId, new Set());
+    this.roomMembers.get(roomId)!.add(client);
+    client.rooms?.add(roomId);
+    this.emit(client, 'battleWatched', { battleId });
+  }
+
+  @SubscribeMessage('unwatchBattle')
+  unwatchBattle(
+    @ConnectedSocket() client: AuthSocket,
+    @MessageBody() body: { battleId?: string },
+  ) {
+    const battleId = String(body?.battleId || '').trim();
+    if (!battleId) return;
+    const roomId = `battle:${battleId}`;
+    this.roomMembers.get(roomId)?.delete(client);
+    client.rooms?.delete(roomId);
+  }
+
+  @SubscribeMessage('battleRoundResult')
+  battleRoundResult(
+    @ConnectedSocket() client: AuthSocket,
+    @MessageBody()
+    body: { battleId?: string; roundIndex?: number; result?: unknown },
+  ) {
+    if (!client.user)
+      return this.emit(client, 'error', { message: 'Unauthorized' });
+
+    const battleId = String(body?.battleId || '').trim();
+    if (!battleId)
+      return this.emit(client, 'error', { message: 'battleId is required' });
+
+    const roomId = `battle:${battleId}`;
+    this.emitRoom(roomId, 'battleRoundResult', {
+      battleId,
+      roundIndex: Number(body?.roundIndex || 0),
+      userId: client.user.userId,
+      username: client.user.username,
+      result: body?.result || null,
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  emitBattleJoined(payload: {
+    battleId: string;
+    userId: string;
+    opponentId: string | null;
+    battleStatus: string;
+  }) {
+    const roomId = `battle:${payload.battleId}`;
+    this.emitRoom(roomId, 'battleJoined', {
+      battleId: payload.battleId,
+      userId: payload.userId,
+      opponentId: payload.opponentId,
+      battleStatus: payload.battleStatus,
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  emitBattleRoundResult(payload: {
+    battleId: string;
+    roundIndex: number;
+    userId: string;
+    result: Record<string, any>;
+    timestamp: string;
+  }) {
+    const roomId = `battle:${payload.battleId}`;
+    this.emitRoom(roomId, 'battleRoundResult', payload);
+  }
+}

--- a/src/battles/battle.module.ts
+++ b/src/battles/battle.module.ts
@@ -1,13 +1,16 @@
 import { Module } from '@nestjs/common';
 import { MongooseModule } from '@nestjs/mongoose';
+import { JwtModule } from '@nestjs/jwt';
 import { BattlesController } from './battle.controller';
 import { BattlesService } from './battle.service';
 import { BattleAiService } from './battle-ai.service';
+import { BattleGateway } from './battle.gateway';
 import { Battle, BattleSchema } from './schemas/battle.schema';
 import {
   BattleHistory,
   BattleHistorySchema,
 } from './schemas/battle-history.schema';
+import { UserSchema } from '../user/schemas/user.schema';
 import { ChallengeModule } from '../challenges/challenge.module';
 import { JudgeModule } from '../judge/judge.module';
 
@@ -16,12 +19,16 @@ import { JudgeModule } from '../judge/judge.module';
     MongooseModule.forFeature([
       { name: Battle.name, schema: BattleSchema },
       { name: BattleHistory.name, schema: BattleHistorySchema },
+      { name: 'User', schema: UserSchema },
     ]),
+    JwtModule.register({
+      secret: process.env.JWT_SECRET || 'defaultJwtSecret',
+    }),
     ChallengeModule,
     JudgeModule,
   ],
   controllers: [BattlesController],
-  providers: [BattlesService, BattleAiService],
+  providers: [BattlesService, BattleAiService, BattleGateway],
   exports: [BattlesService],
 })
 export class BattlesModule {}

--- a/src/battles/battle.service.ts
+++ b/src/battles/battle.service.ts
@@ -1,16 +1,22 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { I18nContext, I18nService } from 'nestjs-i18n';
 import { InjectModel } from '@nestjs/mongoose';
-import { Model } from 'mongoose';
+import { Model, Types } from 'mongoose';
 import { CreateBattleDto } from './dto/create-battle.dto';
 import { UpdateBattleDto } from './dto/update-battle.dto';
 import { Battle, BattleDocument } from './schemas/battle.schema';
-import { BattleStatus } from './battle.enums';
+import { BattleStatus, BattleType } from './battle.enums';
 
 @Injectable()
 export class BattlesService {
   constructor(
     @InjectModel(Battle.name) private readonly model: Model<BattleDocument>,
+    @InjectModel('User') private readonly userModel: Model<any>,
     private readonly i18n: I18nService,
   ) {}
 
@@ -30,7 +36,10 @@ export class BattlesService {
   }
 
   async create(dto: CreateBattleDto): Promise<Battle> {
-    const battleStatus = dto.battleStatus || BattleStatus.PENDING;
+    const battleStatus =
+      dto.battleType === BattleType.ONE_VS_ONE && !dto.opponentId
+        ? BattleStatus.PENDING
+        : dto.battleStatus || BattleStatus.PENDING;
     const payload: Partial<CreateBattleDto> = {
       ...dto,
       idBattle: dto.idBattle || (await this.generateIdBattle()),
@@ -44,25 +53,90 @@ export class BattlesService {
     return created.save();
   }
 
-  async findAll(): Promise<Battle[]> {
-    return this.model.find().exec();
+  private async attachUsernames<T extends Record<string, any>>(
+    battles: T[],
+  ): Promise<Array<T & { creatorUsername?: string; opponentUsername?: string }>> {
+    if (!Array.isArray(battles) || battles.length === 0) return [];
+
+    const idSet = new Set<string>();
+    battles.forEach((battle) => {
+      const creatorId = String(battle?.userId || '').trim();
+      const opponentId = String(battle?.opponentId || '').trim();
+      if (creatorId) idSet.add(creatorId);
+      if (opponentId) idSet.add(opponentId);
+    });
+
+    const ids = Array.from(idSet).filter((id) => Types.ObjectId.isValid(id));
+    if (!ids.length) {
+      return battles.map((battle) => ({
+        ...battle,
+        creatorUsername: undefined,
+        opponentUsername: undefined,
+      }));
+    }
+
+    const users = await this.userModel
+      .find({ _id: { $in: ids } })
+      .select('_id username')
+      .lean()
+      .exec();
+
+    const userMap = new Map<string, string>();
+    users.forEach((user: any) => {
+      userMap.set(String(user?._id || ''), String(user?.username || ''));
+    });
+
+    return battles.map((battle) => {
+      const creatorId = String(battle?.userId || '').trim();
+      const opponentId = String(battle?.opponentId || '').trim();
+      return {
+        ...battle,
+        creatorUsername: userMap.get(creatorId) || undefined,
+        opponentUsername: userMap.get(opponentId) || undefined,
+      };
+    });
   }
 
-  async findByUserId(userId: string): Promise<Battle[]> {
-    return this.model
-      .find({ userId })
+  async findAll(): Promise<any[]> {
+    const rows = await this.model.find().lean().exec();
+    return this.attachUsernames(rows as any[]);
+  }
+
+  async findByUserId(userId: string): Promise<any[]> {
+    const rows = await this.model
+      .find({
+        $or: [{ userId }, { opponentId: userId }],
+      })
       .select('_id idBattle battleStatus battleType roundNumber challengeId opponentId botDifficulty selectChallengeType userId createdAt endedAt winnerUserId')
       .sort({ createdAt: -1 })
       .limit(20)
       .lean()
       .exec();
+    return this.attachUsernames(rows as any[]);
   }
 
-  async findOne(id: string): Promise<Battle> {
-    const found = await this.model.findById(id).exec();
+  async findJoinableBattles(userId: string): Promise<any[]> {
+    const rows = await this.model
+      .find({
+        battleType: BattleType.ONE_VS_ONE,
+        battleStatus: BattleStatus.PENDING,
+        userId: { $ne: userId },
+        $or: [{ opponentId: null }, { opponentId: '' }],
+      })
+      .select('_id idBattle battleStatus battleType roundNumber challengeId opponentId botDifficulty selectChallengeType userId createdAt endedAt winnerUserId')
+      .sort({ createdAt: -1 })
+      .limit(50)
+      .lean()
+      .exec();
+    return this.attachUsernames(rows as any[]);
+  }
+
+  async findOne(id: string): Promise<any> {
+    const found = await this.model.findById(id).lean().exec();
     if (!found)
       throw new NotFoundException(this.tr('battles.notFoundById', { id }));
-    return found;
+    const rows = await this.attachUsernames([found as any]);
+    return rows[0] || found;
   }
 
   async update(id: string, dto: UpdateBattleDto): Promise<Battle> {
@@ -83,6 +157,136 @@ export class BattlesService {
     if (!updated)
       throw new NotFoundException(this.tr('battles.notFoundById', { id }));
     return updated;
+  }
+
+  async joinBattle(id: string, joiningUserId: string): Promise<Battle> {
+    const battle = await this.model.findById(id).exec();
+    if (!battle)
+      throw new NotFoundException(this.tr('battles.notFoundById', { id }));
+
+    if (battle.battleType !== BattleType.ONE_VS_ONE) {
+      throw new BadRequestException('Only 1vs1 battles can be joined');
+    }
+
+    if (battle.userId === joiningUserId) {
+      throw new BadRequestException('You cannot join your own battle');
+    }
+
+    if (battle.battleStatus === BattleStatus.CANCELLED) {
+      throw new BadRequestException('Cannot join a cancelled battle');
+    }
+
+    if (battle.battleStatus === BattleStatus.FINISHED) {
+      throw new BadRequestException('Cannot join a finished battle');
+    }
+
+    if (
+      battle.opponentId &&
+      battle.opponentId !== '' &&
+      battle.opponentId !== joiningUserId
+    ) {
+      throw new ConflictException('Battle already has an opponent');
+    }
+
+    battle.opponentId = joiningUserId;
+    battle.battleStatus = BattleStatus.ACTIVE;
+    battle.startedAt = new Date();
+    return battle.save();
+  }
+
+  async submitRoundResult(
+    id: string,
+    userId: string,
+    input: { roundIndex: number; result: Record<string, any> },
+  ): Promise<{
+    battleId: string;
+    roundIndex: number;
+    userId: string;
+    result: Record<string, any>;
+    timestamp: string;
+  }> {
+    const battle = await this.model.findById(id).exec();
+    if (!battle)
+      throw new NotFoundException(this.tr('battles.notFoundById', { id }));
+
+    if (battle.battleType !== BattleType.ONE_VS_ONE) {
+      throw new BadRequestException('Round submit is only available for 1vs1');
+    }
+
+    const isParticipant = battle.userId === userId || battle.opponentId === userId;
+    if (!isParticipant) {
+      throw new BadRequestException('User is not a participant of this battle');
+    }
+
+    if (battle.battleStatus !== BattleStatus.ACTIVE) {
+      throw new BadRequestException('Battle is not active');
+    }
+
+    const roundIndex = Number(input?.roundIndex ?? -1);
+    if (!Number.isInteger(roundIndex) || roundIndex < 0) {
+      throw new BadRequestException('roundIndex must be a non-negative integer');
+    }
+
+    if (roundIndex >= Number(battle.roundNumber || 0)) {
+      throw new BadRequestException('roundIndex exceeds battle rounds');
+    }
+
+    const result = input?.result || {};
+    const list = Array.isArray((battle as any).pvpRoundResults)
+      ? (battle as any).pvpRoundResults
+      : [];
+
+    const idx = list.findIndex(
+      (it: any) =>
+        Number(it?.roundIndex) === roundIndex && String(it?.userId) === userId,
+    );
+    const payload = {
+      roundIndex,
+      userId,
+      result,
+      updatedAt: new Date(),
+    };
+
+    if (idx >= 0) {
+      list[idx] = payload;
+    } else {
+      list.push(payload);
+    }
+
+    (battle as any).pvpRoundResults = list;
+    await battle.save();
+
+    return {
+      battleId: String((battle as any)?._id || id),
+      roundIndex,
+      userId,
+      result,
+      timestamp: payload.updatedAt.toISOString(),
+    };
+  }
+
+  async getRoundResults(id: string): Promise<
+    Array<{
+      roundIndex: number;
+      userId: string;
+      result: Record<string, any>;
+      timestamp: string;
+    }>
+  > {
+    const battle = await this.model.findById(id).lean().exec();
+    if (!battle)
+      throw new NotFoundException(this.tr('battles.notFoundById', { id }));
+
+    const rows = Array.isArray((battle as any).pvpRoundResults)
+      ? (battle as any).pvpRoundResults
+      : [];
+
+    return rows.map((row: any) => ({
+      roundIndex: Number(row?.roundIndex || 0),
+      userId: String(row?.userId || ''),
+      result: row?.result || {},
+      timestamp: new Date(row?.updatedAt || Date.now()).toISOString(),
+    }));
   }
 
   async remove(id: string): Promise<void> {

--- a/src/battles/dto/submit-round-result.dto.ts
+++ b/src/battles/dto/submit-round-result.dto.ts
@@ -1,0 +1,10 @@
+import { IsInt, IsObject, Min } from 'class-validator';
+
+export class SubmitRoundResultDto {
+  @IsInt()
+  @Min(0)
+  roundIndex: number;
+
+  @IsObject()
+  result: Record<string, any>;
+}

--- a/src/battles/schemas/battle.schema.ts
+++ b/src/battles/schemas/battle.schema.ts
@@ -4,6 +4,23 @@ import { BattleStatus, BattleType, BotDifficulty } from '../battle.enums';
 
 export type BattleDocument = Battle & Document;
 
+@Schema({ _id: false })
+export class PvpRoundResult {
+  @Prop({ required: true })
+  roundIndex: number;
+
+  @Prop({ required: true })
+  userId: string;
+
+  @Prop({ type: Object, required: true })
+  result: Record<string, any>;
+
+  @Prop({ type: Date, default: Date.now })
+  updatedAt: Date;
+}
+
+const PvpRoundResultSchema = SchemaFactory.createForClass(PvpRoundResult);
+
 @Schema({ timestamps: true })
 export class Battle {
   @Prop({ required: true, index: true })
@@ -41,6 +58,9 @@ export class Battle {
 
   @Prop({ required: true, enum: BattleType })
   battleType: BattleType;
+
+  @Prop({ type: [PvpRoundResultSchema], default: [] })
+  pvpRoundResults: PvpRoundResult[];
 }
 
 export const BattleSchema = SchemaFactory.createForClass(Battle);


### PR DESCRIPTION
Introduce a WebSocket gateway and server-side support for real-time 1v1 battles and persisted PvP round results. Changes include:

- Add BattleGateway: handles JWT-authenticated WS connections, room membership, watch/unwatch, broadcasting of round results and join events.
- Expose new controller endpoints: /battles/lobby, POST /:id/join, GET /:id/round-results, POST /:id/round-result; controller now injects BattleGateway to emit events.
- Add SubmitRoundResultDto and PvpRoundResult schema + pvpRoundResults field on Battle schema to persist per-round submissions.
- Add service methods: findJoinableBattles, joinBattle, submitRoundResult, getRoundResults, and attachUsernames helper to include creator/opponent usernames (requires User model injection).
- Update BattlesModule to register JwtModule, include User schema, and provide BattleGateway.
- Add socket.io to package.json (and updated lockfile) as a dependency.

Validation and error handling are added for join and round submissions (e.g. authorization, battle type/status, participant checks, roundIndex bounds).