### PR TITLE
Add CI configs, Dockerfile and Jenkins pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: Backend CI
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+
+jobs:
+  build-and-test:
+    name: Install, test, coverage, build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate coverage
+        run: npm run test:cov -- --runInBand
+
+      - name: Build
+        run: npm run build
+
+      - name: SonarQube scan
+        uses: SonarSource/sonarqube-scan-action@v4
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+        with:
+          args: >
+            -Dsonar.projectKey=algo-arena-backend
+            -Dsonar.projectName=AlgoArena Backend
+            -Dsonar.sources=src
+            -Dsonar.tests=test
+            -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-coverage
+          path: coverage/
+          if-no-files-found: error

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:18-alpine AS build
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . ./
+RUN npm run build
+
+FROM node:18-alpine AS runtime
+WORKDIR /app
+ENV NODE_ENV=production
+
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+COPY --from=build /app/dist ./dist
+
+EXPOSE 3000
+CMD ["node", "dist/main"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,94 @@
+pipeline {
+  agent any
+
+  options {
+    timestamps()
+  }
+
+  tools {
+    nodejs 'Node 18'
+  }
+
+  environment {
+    SONAR_PROJECT_KEY = 'algo-arena-backend'
+    SONAR_PROJECT_NAME = 'AlgoArena Backend'
+    DOCKER_IMAGE_NAME = 'algo-arena-backend'
+    DOCKER_REGISTRY = 'docker.io'
+    DOCKER_CREDENTIALS_ID = 'dockerhub-creds'
+    CD_JOB_NAME = 'AlgoArena-CD'
+  }
+
+  stages {
+    stage('Checkout') {
+      steps {
+        checkout scm
+      }
+    }
+
+    stage('Install dependencies') {
+      steps {
+        sh 'npm ci'
+      }
+    }
+
+    stage('Test and coverage') {
+      steps {
+        sh 'npm run test:cov -- --runInBand'
+      }
+    }
+
+    stage('Build') {
+      steps {
+        sh 'npm run build'
+      }
+    }
+
+    stage('SonarQube analysis') {
+      steps {
+        script {
+          def scannerHome = tool 'SonarScanner'
+          withSonarQubeEnv('SonarQube') {
+            sh "${scannerHome}/bin/sonar-scanner -Dsonar.projectKey=${SONAR_PROJECT_KEY} -Dsonar.projectName=${SONAR_PROJECT_NAME} -Dsonar.sources=src -Dsonar.tests=src,test -Dsonar.test.inclusions=src/**/*.spec.ts,test/**/*.e2e-spec.ts -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info"
+          }
+        }
+      }
+    }
+
+    stage('Quality Gate') {
+      steps {
+        timeout(time: 10, unit: 'MINUTES') {
+          waitForQualityGate abortPipeline: true
+        }
+      }
+    }
+
+    stage('Docker build and push') {
+      steps {
+        script {
+          def imageTag = "${env.DOCKER_REGISTRY}/${env.DOCKER_IMAGE_NAME}:${env.BUILD_NUMBER}"
+
+          docker.withRegistry("https://${env.DOCKER_REGISTRY}", env.DOCKER_CREDENTIALS_ID) {
+            def image = docker.build(imageTag)
+            image.push()
+            image.push('latest')
+          }
+        }
+      }
+    }
+
+    stage('Trigger CD') {
+      steps {
+        build job: env.CD_JOB_NAME, wait: false, parameters: [
+          string(name: 'IMAGE_TAG', value: "${env.DOCKER_REGISTRY}/${env.DOCKER_IMAGE_NAME}:${env.BUILD_NUMBER}"),
+          string(name: 'IMAGE_LATEST', value: "${env.DOCKER_REGISTRY}/${env.DOCKER_IMAGE_NAME}:latest")
+        ]
+      }
+    }
+  }
+
+  post {
+    always {
+      archiveArtifacts artifacts: 'coverage/**', allowEmptyArchive: false
+    }
+  }
+}


### PR DESCRIPTION
Add GitHub Actions workflow (backend CI) to run install, tests with coverage, build, SonarQube scan and upload coverage artifact. Add a multi-stage Dockerfile using Node 18 Alpine for build and runtime (exposes port 3000 and runs dist/main). Add a Jenkinsfile pipeline with stages for checkout, install, test/coverage, build, SonarQube analysis and quality gate, Docker build/push, and a downstream CD trigger. Secrets/configs (SONAR_TOKEN, SONAR_HOST_URL, Docker credentials, SonarScanner tool) are referenced via CI/Jenkins environment and credentials.