### PR TITLE
Small fixes: parsing, comparisons, and prefix

### DIFF
--- a/src/ai-agents/ai-agents.service.ts
+++ b/src/ai-agents/ai-agents.service.ts
@@ -554,7 +554,7 @@ export class AiAgentsService {
 
   private toI18nKey(filePath: string, index: number): string {
     const normalized = filePath
-      .replaceAll(/\\/g, '/')
+      .replaceAll('\\', '/')
       .replaceAll(/^.*\/src\//g, '')
       .replaceAll(/\.(jsx|tsx|js|ts)$/gi, '')
       .split('/')

--- a/src/code-executor/code-executor.service.ts
+++ b/src/code-executor/code-executor.service.ts
@@ -196,9 +196,9 @@ ${code}
 
 # Input handling
 try:
-  user_input = json.loads('''${testCase.input.replaceAll(/'/g, "\\'")}''')
+  user_input = json.loads('''${testCase.input.replaceAll("'", "\\'")}''')
 except:
-  user_input = '''${testCase.input.replaceAll(/'/g, "\\'")}'''
+  user_input = '''${testCase.input.replaceAll("'", "\\'")}'''
 
 # Call the function (expecting a function named 'solution' or similar)
 # This is flexible - if code returns directly, use that
@@ -347,10 +347,10 @@ except Exception as e:
       return true;
     }
     // Try numeric comparison if both are numbers
-    const actualNum = parseFloat(actualTrimmed);
-    const expectedNum = parseFloat(expectedTrimmed);
+    const actualNum = Number.parseFloat(actualTrimmed);
+    const expectedNum = Number.parseFloat(expectedTrimmed);
 
-    if (!isNaN(actualNum) && !isNaN(expectedNum)) {
+    if (!Number.isNaN(actualNum) && !Number.isNaN(expectedNum)) {
       // Allow small floating point differences
       return Math.abs(actualNum - expectedNum) < 0.0001;
     }

--- a/src/judge/services/docker-execution.service.ts
+++ b/src/judge/services/docker-execution.service.ts
@@ -256,7 +256,7 @@ export class DockerExecutionService implements OnModuleInit {
       clearTimeout(timeoutHandle);
 
       if (stopStatsSampler) stopStatsSampler();
-      if (statsSamplerPromise) {
+      if (statsSamplerPromise !== undefined) {
         const sampled = await statsSamplerPromise.catch(() => null);
         if (sampled) {
           metricRecord.peakCpuPercent = sampled.peakCpuPercent;

--- a/src/judge/services/ml-complexity.service.ts
+++ b/src/judge/services/ml-complexity.service.ts
@@ -173,7 +173,7 @@ export class MlComplexityService {
 
   private trimTrailingSlashes(value: string): string {
     let end = value.length;
-    while (end > 0 && value.charCodeAt(end - 1) === 47) {
+    while (end > 0 && value.codePointAt(end - 1) === 47) {
       end--;
     }
     return end === value.length ? value : value.slice(0, end);

--- a/src/judge/utils/comparison.util.ts
+++ b/src/judge/utils/comparison.util.ts
@@ -8,7 +8,7 @@ function normalizeForComparison(value: unknown): unknown {
   }
   if (value && typeof value === 'object') {
     const record = value as Record<string, unknown>;
-    const keys = Object.keys(record).sort();
+    const keys = Object.keys(record).sort((left, right) => left.localeCompare(right));
     const normalized: Record<string, unknown> = {};
     for (const key of keys) {
       normalized[key] = normalizeForComparison(record[key]);

--- a/src/judge/utils/input-parser.util.ts
+++ b/src/judge/utils/input-parser.util.ts
@@ -208,7 +208,7 @@ function convertSingleQuotedStrings(input: string): string {
   return input.replaceAll(
     /'([^'\\]*(?:\\.[^'\\]*)*)'/g,
     (_match, content: string) => {
-      const escaped = content.replaceAll(/"/g, '\\"');
+      const escaped = content.replaceAll('"', '\\"');
       return `"${escaped}"`;
     },
   );

--- a/src/main.ts
+++ b/src/main.ts
@@ -56,6 +56,7 @@ async function bootstrap() {
   setDefaultResultOrder('ipv4first');
 
   const app = await NestFactory.create<NestExpressApplication>(AppModule);
+  app.setGlobalPrefix('api');
   app.useWebSocketAdapter(new WsAdapter(app));
   const allowedOrigins = resolveAllowedOrigins(process.env.CORS_ORIGIN);
 

--- a/src/onboarding/onboarding.controller.ts
+++ b/src/onboarding/onboarding.controller.ts
@@ -31,7 +31,7 @@ export class OnboardingController {
         // Try UTF-8 first (strip BOM if present)
         const tryUtf8 = (b: Buffer) => {
           let s = b.toString('utf8');
-          if (s.charCodeAt(0) === 0xfeff) s = s.slice(1);
+          if (s.codePointAt(0) === 0xfeff) s = s.slice(1);
           return s;
         };
 

--- a/src/onboarding/onboarding.service.ts
+++ b/src/onboarding/onboarding.service.ts
@@ -307,7 +307,7 @@ export class OnboardingService {
           parsed.memory ??
           (parsed as any).space_complexity ??
           (parsed as any).spaceComplexity ??
-          NaN,
+          Number.NaN,
       );
       const space = Number.isFinite(rawSpace) ? this.clamp(rawSpace) : 50;
       const style = this.clamp(Number(parsed.style) || 50);

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -263,7 +263,7 @@ Audit logs are created for every call:
     @Body() body: { xpDelta: number },
   ) {
     const xpDelta = Number(body?.xpDelta);
-    if (!isFinite(xpDelta)) {
+    if (!Number.isFinite(xpDelta)) {
       throw new BadRequestException(this.tr('userController.xpDeltaInvalid'));
     }
 


### PR DESCRIPTION
Apply a set of small robustness and correctness fixes across the codebase:

- ai-agents: normalize file path replaceAll call to use string for backslash handling.
- code-executor: use simple string replace for quoting in test inputs; switch to Number.parseFloat and Number.isNaN for numeric comparisons.
- docker-execution: explicitly check statsSamplerPromise !== undefined before awaiting.
- ml-complexity & onboarding: use codePointAt instead of charCodeAt for correct Unicode handling (BOM and trailing slash checks).
- comparison util: sort object keys with localeCompare for stable, locale-aware ordering.
- input-parser util: use string replace for double-quote escaping in single-quoted strings.
- main: set global API prefix (app.setGlobalPrefix('api')).
- onboarding.service & user.controller: use Number.NaN and Number.isFinite for clearer numeric semantics.

These changes increase correctness for edge cases (Unicode, numeric checks, and string escaping) and add a global API prefix.